### PR TITLE
Add `partner-charts-ci cull` subcommand for removing chart versions past a certain age

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,46 @@
+name: Pull request checks
+
+on: [pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Run unit tests
+        run: go test ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v5
+        with:
+          version: v1.57
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Test build of binaries
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: build --snapshot

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode/
+bin/
+dist/

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/rancher/charts-build-scripts v0.4.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli v1.22.14
-	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.12.1
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -143,6 +142,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.27.2 // indirect
 	k8s.io/apiextensions-apiserver v0.27.2 // indirect
 	k8s.io/apimachinery v0.27.2 // indirect

--- a/pkg/conform/export.go
+++ b/pkg/conform/export.go
@@ -64,7 +64,9 @@ func ApplyOverlayFiles(packagePath string) error {
 		for _, dir := range dirList {
 			generatedPath := filepath.Join(packagePath, "charts", dir)
 			if _, err := os.Stat(generatedPath); os.IsNotExist(err) {
-				os.MkdirAll(generatedPath, 0755)
+				if err := os.MkdirAll(generatedPath, 0755); err != nil {
+					return fmt.Errorf("failed to mkdir %q: %w", generatedPath, err)
+				}
 			}
 		}
 
@@ -118,7 +120,9 @@ func LinkOverlayFiles(packagePath string) error {
 		for _, dir := range dirList {
 			generatedPath := filepath.Join(packagePath, generatedDir, overlayDir, dir)
 			if _, err := os.Stat(generatedPath); os.IsNotExist(err) {
-				os.MkdirAll(generatedPath, 0755)
+				if err := os.MkdirAll(generatedPath, 0755); err != nil {
+					return fmt.Errorf("failed to mkdir %q: %w", generatedPath, err)
+				}
 			}
 		}
 

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -1,6 +1,7 @@
 package parse
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -56,7 +57,9 @@ func (packageYaml PackageYaml) Write(overWrite bool) error {
 		if !overWrite {
 			return nil
 		} else {
-			packageYaml.Remove()
+			if err := packageYaml.Remove(); err != nil {
+				return fmt.Errorf("failed to remove package.yaml: %w", err)
+			}
 		}
 	}
 

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -163,8 +163,12 @@ func CompareDirectories(leftPath, rightPath string, exclude map[string]struct{})
 		return nil
 	}
 
-	filepath.Walk(leftPath, compareLeft)
-	filepath.Walk(rightPath, compareRight)
+	if err := filepath.Walk(leftPath, compareLeft); err != nil {
+		return DirectoryComparison{}, fmt.Errorf("failed while walking %q: %w", leftPath, err)
+	}
+	if err := filepath.Walk(rightPath, compareRight); err != nil {
+		return DirectoryComparison{}, fmt.Errorf("failed while walking %q: %w", rightPath, err)
+	}
 
 	if len(directoryComparison.Modified)+len(directoryComparison.Added)+len(directoryComparison.Removed) > 0 {
 		directoryComparison.Match = false


### PR DESCRIPTION
Like it says in the title.

As a bonus, I've added the `pull-request.yaml` workflow for PR checks, and corrected the things `golangci-lint` complained about.

Reviewing this PR by commit will make the most sense.