### PR TITLE
Use v5 of `setup-go` action

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,8 +13,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Setup golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
+
       - name: Goreleaser
         uses: goreleaser/goreleaser-action@v4
         with:


### PR DESCRIPTION
According to a warning on recent workflow runs:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-go@v4.
```
This PR updates all uses of the `setup-go` action to v5.