### PR TITLE
Add `go mod tidy` to try to fix flaky linting in GHA

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -24,6 +24,9 @@ jobs:
         with:
           go-version: '1.20'
 
+      - name: Run `go mod tidy` to avoid golangci-lint error
+        run: go mod tidy
+
       - name: Run linter
         uses: golangci/golangci-lint-action@v5
         with:


### PR DESCRIPTION
Recently I have been creating a few PRs in this repo. Most of the time, the `lint` check fails on them. This PR should fix that.
```
Running [/home/runner/golangci-lint-1.57.2-linux-amd64/golangci-lint run --out-format=github-actions] in [/home/runner/work/partner-charts-ci/partner-charts-ci] ...
  level=error msg="Running error: context loading failed: no go files to analyze: running `go mod tidy` may solve the problem"
  level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
  
  Error: golangci-lint exit with code 4
  Ran golangci-lint in 60182ms
```