### PR TITLE
Remove `prepare` subcommand, plus other miscellaneous improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-git/go-git/v5 v5.7.0
 	github.com/google/go-github/v53 v53.2.0
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli v1.22.14
 	helm.sh/helm/v3 v3.12.1
 	sigs.k8s.io/yaml v1.3.0
@@ -80,6 +81,7 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,8 @@ github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -391,8 +391,9 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli v1.22.14 h1:ebbhrRiGK2i4naQJr+1Xj92HXZCrK7MsyTS/ob3HnAk=
 github.com/urfave/cli v1.22.14/go.mod h1:X0eDS6pD6Exaclxm99NJ3FiCDRED7vIHpx2mDOHLvkA=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/main.go
+++ b/main.go
@@ -617,16 +617,12 @@ func initializeChart(packagePath string, sourceMetadata fetcher.ChartSourceMetad
 		return nil, err
 	}
 
-	chartDirectoryPath := path.Join(packagePath, repositoryChartsDir)
-	if err := conform.StandardizeChartDirectory(chartDirectoryPath, ""); err != nil {
-		return nil, fmt.Errorf("failed to standardize chart directory: %w", err)
-	}
-
 	err = conform.ApplyOverlayFiles(packagePath)
 	if err != nil {
 		return nil, err
 	}
 
+	chartDirectoryPath := path.Join(packagePath, repositoryChartsDir)
 	helmChart, err := loader.Load(chartDirectoryPath)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -1276,11 +1276,6 @@ func cleanCharts(c *cli.Context) {
 	}
 }
 
-// CLI function call - Prepares package(s) for modification via patch
-func prepareCharts(c *cli.Context) {
-	generateChanges(false, false)
-}
-
 // CLI function call - Generates all changes for available packages,
 // Checking against upstream version, prepare, patch, clean, and index update
 // Does not commit
@@ -1474,16 +1469,6 @@ func main() {
 			Name:   "list",
 			Usage:  "Print a list of all tracked upstreams in current repository",
 			Action: listPackages,
-		},
-		{
-			Name:   "prepare",
-			Usage:  "Pull chart from upstream and prepare for alteration via patch",
-			Action: prepareCharts,
-			Hidden: true, // Hidden because this subcommand does not execute overrideIcons
-			// that is necessary in the current release process,
-			// this should not be executed and pushed to production
-			// otherwise we will not have the icons updated at index.yaml.
-			// You should use the auto command instead.
 		},
 		{
 			Name:   "clean",

--- a/pkg/conform/conform_test.go
+++ b/pkg/conform/conform_test.go
@@ -1,0 +1,114 @@
+package conform
+
+import (
+	"testing"
+
+	"helm.sh/helm/v3/pkg/chart"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testAnnotation = "test-annotation"
+
+func TestMain(t *testing.T) {
+	t.Run("AnnotateChart", func(t *testing.T) {
+		t.Run("should not modify an existing annotation when override is false", func(t *testing.T) {
+			firstValue := "testvalue"
+			helmChart := &chart.Chart{
+				Metadata: &chart.Metadata{
+					Annotations: map[string]string{
+						testAnnotation: firstValue,
+					},
+				},
+			}
+			result := AnnotateChart(helmChart, testAnnotation, "newtestvalue", false)
+			assert.False(t, result)
+			assert.Equal(t, firstValue, helmChart.Metadata.Annotations[testAnnotation])
+		})
+
+		t.Run("should modify an existing annotation when override is true", func(t *testing.T) {
+			firstValue := "testvalue"
+			secondValue := "newtestvalue"
+			helmChart := &chart.Chart{
+				Metadata: &chart.Metadata{
+					Annotations: map[string]string{
+						testAnnotation: firstValue,
+					},
+				},
+			}
+			result := AnnotateChart(helmChart, testAnnotation, secondValue, true)
+			assert.True(t, result)
+			assert.Equal(t, secondValue, helmChart.Metadata.Annotations[testAnnotation])
+		})
+
+		t.Run("should set an annotation that is not already set", func(t *testing.T) {
+			testValue := "testvalue"
+			helmChart := &chart.Chart{
+				Metadata: &chart.Metadata{
+					Annotations: map[string]string{},
+				},
+			}
+			result := AnnotateChart(helmChart, testAnnotation, testValue, true)
+			assert.True(t, result)
+			assert.Equal(t, testValue, helmChart.Metadata.Annotations[testAnnotation])
+		})
+	})
+
+	t.Run("DeannotateChart", func(t *testing.T) {
+		t.Run("should not change Chart.Metadata.Annotation if it is nil", func(t *testing.T) {
+			helmChart := &chart.Chart{
+				Metadata: &chart.Metadata{},
+			}
+			result := DeannotateChart(helmChart, testAnnotation, "")
+			assert.False(t, result)
+			assert.Nil(t, helmChart.Metadata.Annotations)
+		})
+
+		t.Run("should remove the annotation when an empty value is passed", func(t *testing.T) {
+			testValue := "testvalue"
+			helmChart := &chart.Chart{
+				Metadata: &chart.Metadata{
+					Annotations: map[string]string{
+						testAnnotation: testValue,
+					},
+				},
+			}
+			result := DeannotateChart(helmChart, testAnnotation, "")
+			assert.True(t, result)
+			_, ok := helmChart.Metadata.Annotations[testAnnotation]
+			assert.False(t, ok)
+		})
+
+		t.Run("should remove the annotation when the exact value is passed", func(t *testing.T) {
+			testValue := "testvalue"
+			helmChart := &chart.Chart{
+				Metadata: &chart.Metadata{
+					Annotations: map[string]string{
+						testAnnotation: testValue,
+					},
+				},
+			}
+			result := DeannotateChart(helmChart, testAnnotation, testValue)
+			assert.True(t, result)
+			_, ok := helmChart.Metadata.Annotations[testAnnotation]
+			assert.False(t, ok)
+		})
+
+		t.Run("should not remove the annotation when a non-empty non-matching value is passed", func(t *testing.T) {
+			testValue := "testvalue"
+			passedValue := "passedvalue"
+			helmChart := &chart.Chart{
+				Metadata: &chart.Metadata{
+					Annotations: map[string]string{
+						testAnnotation: testValue,
+					},
+				},
+			}
+			result := DeannotateChart(helmChart, testAnnotation, passedValue)
+			assert.False(t, result)
+			val, ok := helmChart.Metadata.Annotations[testAnnotation]
+			assert.True(t, ok)
+			assert.Equal(t, testValue, val)
+		})
+	})
+}

--- a/pkg/conform/export.go
+++ b/pkg/conform/export.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
 )
 
@@ -153,22 +152,6 @@ func RemoveOverlayFiles(packagePath string) error {
 	}
 
 	return nil
-}
-
-// Load and Unloads Chart to ensure consistent layout for overlay
-func StandardizeChartDirectory(sourcePath string, targetPath string) error {
-	helmChart, err := loader.Load(sourcePath)
-	if err != nil {
-		return fmt.Errorf("failed to load chart directory: %w", err)
-	}
-
-	if targetPath == "" {
-		targetPath = sourcePath
-		os.RemoveAll(sourcePath)
-	}
-
-	return ExportChartDirectory(helmChart, targetPath)
-
 }
 
 func ExportChartDirectory(chart *chart.Chart, targetPath string) error {


### PR DESCRIPTION
This PR removes the `prepare` subcommand, and also improves a few other trouble spots in the codebase that I noticed while working on it.

I recommend reviewing this PR by commit. I have structured it so that each commit does a specific and easy-to-review thing. I have included justification in the commit message where I felt it was necessary.