### PR TITLE
Integrate icon URL overwriting code properly

### DIFF
--- a/main.go
+++ b/main.go
@@ -808,6 +808,10 @@ func addAnnotations(packageWrapper PackageWrapper, helmChart *chart.Chart) error
 		annotations[annotationHidden] = "true"
 	}
 
+	// TODO: this is sketchy. We end up changing the repository URL of each
+	// dependency without downloading dependencies. This can't be right.
+	// And if it is, this needs a comment explaining what is going on.
+	// Need to investigate further.
 	if !packageWrapper.UpstreamYaml.RemoteDependencies {
 		for _, d := range helmChart.Metadata.Dependencies {
 			d.Repository = fmt.Sprintf("file://./charts/%s", d.Name)
@@ -829,13 +833,12 @@ func addAnnotations(packageWrapper PackageWrapper, helmChart *chart.Chart) error
 	if packageWrapper.UpstreamYaml.Namespace != "" {
 		annotations[annotationNamespace] = packageWrapper.UpstreamYaml.Namespace
 	}
-	if helmChart.Metadata.KubeVersion != "" && packageWrapper.UpstreamYaml.ChartYaml.KubeVersion != "" {
+
+	if packageWrapper.UpstreamYaml.ChartYaml.KubeVersion != "" {
 		annotations[annotationKubeVersion] = packageWrapper.UpstreamYaml.ChartYaml.KubeVersion
 		helmChart.Metadata.KubeVersion = packageWrapper.UpstreamYaml.ChartYaml.KubeVersion
 	} else if helmChart.Metadata.KubeVersion != "" {
 		annotations[annotationKubeVersion] = helmChart.Metadata.KubeVersion
-	} else if packageWrapper.UpstreamYaml.ChartYaml.KubeVersion != "" {
-		annotations[annotationKubeVersion] = packageWrapper.UpstreamYaml.ChartYaml.KubeVersion
 	}
 
 	if packageVersion := packageWrapper.UpstreamYaml.PackageVersion; packageVersion != 0 {

--- a/main.go
+++ b/main.go
@@ -871,10 +871,11 @@ func ensureFeaturedAnnotation(existingCharts, newCharts []*chart.Chart) ([]*char
 		if featuredAnnotationValue != "" && featuredAnnotationValue != val {
 			return nil, fmt.Errorf("found two different values for featured annotation %q and %q", featuredAnnotationValue, val)
 		}
+		featuredAnnotationValue = val
 	}
 	if featuredAnnotationValue == "" {
 		// the chart is not featured
-		return nil, nil
+		return modifiedCharts, nil
 	}
 
 	// set featured annotation on last of new charts

--- a/main.go
+++ b/main.go
@@ -735,6 +735,7 @@ func integrateCharts(packageWrapper PackageWrapper, existingCharts, newCharts []
 		if err := applyOverlayFiles(overlayFiles, newChart); err != nil {
 			return nil, fmt.Errorf("failed to apply overlay files to chart %q version %q: %w", newChart.Name(), newChart.Metadata.Version, err)
 		}
+		conform.OverlayChartMetadata(newChart, packageWrapper.UpstreamYaml.ChartYaml)
 		if err := addAnnotations(packageWrapper, newChart); err != nil {
 			return nil, fmt.Errorf("failed to add annotations to chart %q version %q: %w", newChart.Name(), newChart.Metadata.Version, err)
 		}
@@ -827,8 +828,6 @@ func addAnnotations(packageWrapper PackageWrapper, helmChart *chart.Chart) error
 	} else {
 		annotations[annotationReleaseName] = packageWrapper.Name
 	}
-
-	conform.OverlayChartMetadata(helmChart, packageWrapper.UpstreamYaml.ChartYaml)
 
 	if packageWrapper.UpstreamYaml.Namespace != "" {
 		annotations[annotationNamespace] = packageWrapper.UpstreamYaml.Namespace

--- a/main.go
+++ b/main.go
@@ -650,7 +650,7 @@ func initializeChart(packagePath string, sourceMetadata fetcher.ChartSourceMetad
 	return helmChart, nil
 }
 
-func ApplyUpdates(packageWrapper PackageWrapper, writeChart bool) error {
+func ApplyUpdates(packageWrapper PackageWrapper) error {
 	logrus.Debugf("Conforming package from %s\n", packageWrapper.Path)
 
 	existingCharts, err := loadExistingCharts(packageWrapper.ParsedVendor, packageWrapper.Name)
@@ -677,10 +677,6 @@ func ApplyUpdates(packageWrapper PackageWrapper, writeChart bool) error {
 
 	if err := integrateCharts(packageWrapper, existingCharts, newCharts); err != nil {
 		return fmt.Errorf("failed to reconcile charts for package %q: %w", packageWrapper.Name, err)
-	}
-
-	if !writeChart {
-		return nil
 	}
 
 	allCharts := make([]*chart.Chart, 0, len(existingCharts)+len(newCharts))

--- a/main.go
+++ b/main.go
@@ -842,7 +842,7 @@ func addAnnotations(packageWrapper PackageWrapper, helmChart *chart.Chart) error
 	}
 
 	if packageVersion := packageWrapper.UpstreamYaml.PackageVersion; packageVersion != 0 {
-		generatedVersion, err := conform.GeneratePackageVersion(helmChart.Metadata.Version, &packageVersion, "")
+		generatedVersion, err := conform.GeneratePackageVersion(helmChart.Metadata.Version, &packageVersion)
 		helmChart.Metadata.Version = generatedVersion
 		if err != nil {
 			return fmt.Errorf("failed to generate version: %w", err)
@@ -975,7 +975,7 @@ func conformPackage(packageWrapper PackageWrapper) error {
 		}
 
 		if packageVersion := packageWrapper.UpstreamYaml.PackageVersion; packageVersion != 0 {
-			helmChart.Metadata.Version, err = conform.GeneratePackageVersion(helmChart.Metadata.Version, &packageVersion, "")
+			helmChart.Metadata.Version, err = conform.GeneratePackageVersion(helmChart.Metadata.Version, &packageVersion)
 			if err != nil {
 				logrus.Error(err)
 			}

--- a/main.go
+++ b/main.go
@@ -639,7 +639,7 @@ func parseVendor(upstreamYamlVendor, chartName, packagePath string) (string, str
 }
 
 func ApplyUpdates(packageWrapper PackageWrapper) error {
-	logrus.Debugf("Conforming package from %s\n", packageWrapper.Path)
+	logrus.Debugf("Applying updates for package %s/%s\n", packageWrapper.ParsedVendor, packageWrapper.Name)
 
 	existingCharts, err := loadExistingCharts(packageWrapper.ParsedVendor, packageWrapper.Name)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -835,7 +835,6 @@ func addAnnotations(packageWrapper PackageWrapper, helmChart *chart.Chart) error
 
 	if packageWrapper.UpstreamYaml.ChartYaml.KubeVersion != "" {
 		annotations[annotationKubeVersion] = packageWrapper.UpstreamYaml.ChartYaml.KubeVersion
-		helmChart.Metadata.KubeVersion = packageWrapper.UpstreamYaml.ChartYaml.KubeVersion
 	} else if helmChart.Metadata.KubeVersion != "" {
 		annotations[annotationKubeVersion] = helmChart.Metadata.KubeVersion
 	}

--- a/main.go
+++ b/main.go
@@ -72,25 +72,32 @@ func NewChartWrapper(helmChart *chart.Chart) *ChartWrapper {
 	}
 }
 
-// PackageWrapper is a representation of relevant package metadata
+// PackageWrapper is the manifestation of the concept of a package,
+// which is configuration that refers to an upstream helm chart plus
+// any local modifications that may be made to those helm charts as
+// they are being integrated into the partner charts repository.
+//
+// PackageWrapper is not called Package because the most obvious name
+// for instances of it would be "package", which conflicts with the
+// "package" golang keyword.
 type PackageWrapper struct {
-	//Chart Display Name
-	DisplayName string
-	//Filtered subset of versions to-be-fetched
-	FetchVersions repo.ChartVersions
-	//Path stores the package path in current repository
-	Path string
-	//LatestStored stores the latest version of the chart currently in the repo
-	LatestStored repo.ChartVersion
-	//Chart name
+	// The developer-facing name of the chart
 	Name string
-	//SourceMetadata represents metadata fetched from the upstream repository
+	// The user-facing (i.e. pretty) chart name
+	DisplayName string
+	// Filtered subset of versions to be fetched
+	FetchVersions repo.ChartVersions
+	// Path stores the package path in current repository
+	Path string
+	// LatestStored stores the latest version of the chart currently in the repo
+	LatestStored repo.ChartVersion
+	// SourceMetadata represents metadata fetched from the upstream repository
 	SourceMetadata *fetcher.ChartSourceMetadata
-	//UpstreamYaml represents the values set in the package's upstream.yaml file
+	// The package's upstream.yaml file
 	UpstreamYaml *parse.UpstreamYaml
-	//Chart vendor
+	// The user-facing (i.e. pretty) chart vendor name
 	Vendor string
-	//Formatted version of chart vendor
+	// The developer-facing chart vendor name
 	ParsedVendor string
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -307,7 +307,6 @@ func TestMain(t *testing.T) {
 				}
 				assert.True(t, ok)
 				assert.Equal(t, testCase.ExpectedValue, value)
-				assert.Equal(t, testCase.ExpectedValue, helmChart.Metadata.KubeVersion)
 			}
 		})
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(t *testing.T) {
+	t.Run("PackageWrapper", func(t *testing.T) {
+		t.Run("GetOverlayFiles", func(t *testing.T) {
+			t.Run("should parse overlay files properly", func(t *testing.T) {
+				packageWrapper := PackageWrapper{
+					Path: filepath.Join("testdata", "getOverlayFiles"),
+				}
+				actualOverlayFiles, err := packageWrapper.GetOverlayFiles()
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				expectedOverlayFiles := map[string][]byte{
+					"file1.txt":                        []byte("this is file 1\n"),
+					"file2.txt":                        []byte("this is file 2\n"),
+					filepath.Join("dir1", "file3.txt"): []byte("this is file 3\n"),
+				}
+				for expectedPath, expectedValue := range expectedOverlayFiles {
+					actualValue, ok := actualOverlayFiles[expectedPath]
+					assert.True(t, ok)
+					assert.Equal(t, expectedValue, actualValue)
+				}
+				assert.Equal(t, len(expectedOverlayFiles), len(actualOverlayFiles))
+			})
+		})
+	})
+}

--- a/pkg/conform/conform.go
+++ b/pkg/conform/conform.go
@@ -163,10 +163,7 @@ func StripPackageVersion(chartVersion string) string {
 	return version.String()
 }
 
-func GeneratePackageVersion(upstreamChartVersion string, packageVersion *int, version string) (string, error) {
-	if version != "" {
-		return version, nil
-	}
+func GeneratePackageVersion(upstreamChartVersion string, packageVersion *int) (string, error) {
 	if packageVersion != nil {
 		chartVersion, err := semver.NewVersion(upstreamChartVersion)
 		if err != nil {

--- a/pkg/conform/conform.go
+++ b/pkg/conform/conform.go
@@ -174,6 +174,10 @@ func GeneratePackageVersion(upstreamChartVersion string, packageVersion *int) (s
 			return "", fmt.Errorf("package version %d is greater than maximum of %d", *packageVersion, MaxPatchNum)
 		}
 
+		// TODO: when chartVersion.Patch() == 0, then we get a patch version of 1,
+		// assuming PatchVersion is set to 1 in the upstream.yaml (which it is for
+		// all packages that set PatchVersion at the time of writing). I don't
+		// think this is the intent of the function, so this behavior should be fixed.
 		patchVersion := PatchNumMultiplier*chartVersion.Patch() + uint64(*packageVersion)
 
 		split := strings.Split(chartVersion.String(), ".")

--- a/pkg/conform/conform.go
+++ b/pkg/conform/conform.go
@@ -61,12 +61,9 @@ func OverlayChartMetadata(helmChart *chart.Chart, overlay chart.Metadata) {
 			AnnotateChart(helmChart, annotation, value, true)
 		}
 	}
-	/* Leaving in place, commented, to match upstream Helm metadata
-	   Annotation 'catalog.cattle.io/kube-version' is prefered
 	if overlay.KubeVersion != "" {
 		helmChart.Metadata.KubeVersion = overlay.KubeVersion
 	}
-	*/
 	if overlay.Dependencies != nil {
 		helmChart.Metadata.Dependencies = append(helmChart.Metadata.Dependencies, overlay.Dependencies...)
 	}

--- a/pkg/icons/icons.go
+++ b/pkg/icons/icons.go
@@ -53,17 +53,17 @@ func CheckFilesStructure() {
 	}
 }
 
-// CheckForDownloadedIcon will check if the icon is already downloaded and return the path
-func CheckForDownloadedIcon(packageName string) string {
+// GetDownloadedIconPath checks if the icon is already downloaded and return the path
+func GetDownloadedIconPath(packageName string) (string, error) {
 
 	for _, ext := range extensions {
 		filePath := fmt.Sprintf("assets/icons/%s%s", packageName, ext)
 		if exist := Exists(filePath); exist {
-			return fmt.Sprintf("file://%s", filePath)
+			return fmt.Sprintf("file://%s", filePath), nil
 		}
 	}
 
-	return ""
+	return "", fmt.Errorf("no icon found for package %q", packageName)
 }
 
 // OverrideIconValues will change the metade icon URL to a local icon path for the index.yaml

--- a/testdata/getOverlayFiles/overlay/dir1/file3.txt
+++ b/testdata/getOverlayFiles/overlay/dir1/file3.txt
@@ -1,0 +1,1 @@
+this is file 3

--- a/testdata/getOverlayFiles/overlay/file1.txt
+++ b/testdata/getOverlayFiles/overlay/file1.txt
@@ -1,0 +1,1 @@
+this is file 1

--- a/testdata/getOverlayFiles/overlay/file2.txt
+++ b/testdata/getOverlayFiles/overlay/file2.txt
@@ -1,0 +1,1 @@
+this is file 2


### PR DESCRIPTION
Originally, I intended this PR to be about integrating the icon URL code properly. This PR does this, but it also does quite a bit more. When I started to try to understand how the code works, I realized that the `partner-charts-ci` codebase is quite messy and hard to understand. There were (and outside of the code changed by this PR there still are) many weird things being done with no explanation. There was no way to integrate the icon URL code without making major changes to this code, so that is what I did. I think that you'll find that the new code is much easier to understand. This is a very important PR for `partner-charts-ci` because it enables long-term maintenance.

As you read through the code, you'll see I've added `TODO` comments for things that need to be done in subsequent PRs. I will create jira issues for these things shortly.

Also, we will need to do a migration: this PR changes the layout of `charts/` to be more like `charts-build-scripts`: it contains the contents of every chart version, rather than just the latest one as is currently the case in rancher/partner-charts. This migration will affect only the `charts/` directory on the `main-source` branch, i.e. it will not affect the released charts, which are on the `main` branch of rancher/partner-charts.

Reviewing this PR by commit will make the most sense. There is one large commit, but I have kept the rest to a manageable size. I'm sorry it is such a large PR, but there is no other way to do this type of change.