### PR TITLE
Do not return error from loadExistingCharts when asset directory does not exist

### DIFF
--- a/main.go
+++ b/main.go
@@ -717,7 +717,9 @@ func writeCharts(packageWrapper PackageWrapper, chartWrappers []*ChartWrapper) e
 func loadExistingCharts(vendor string, packageName string) ([]*ChartWrapper, error) {
 	assetsPath := filepath.Join(getRepoRoot(), repositoryAssetsDir, vendor)
 	tgzFiles, err := os.ReadDir(assetsPath)
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
+		return []*ChartWrapper{}, nil
+	} else if err != nil {
 		return nil, fmt.Errorf("failed to read dir %q: %w", assetsPath, err)
 	}
 	existingChartWrappers := make([]*ChartWrapper, 0, len(tgzFiles))


### PR DESCRIPTION
I discovered this while testing https://github.com/rancher/partner-charts/pull/1035. `loadExistingCharts` reads `assets/<vendor>` in order to get a slice of existing charts. Currently it returns an error if the directory does not exist (i.e. the vendor is new and does not yet have any assets). Instead, it should return an empty slice and `nil` error.