### PR TITLE
Fix `commitChanges`

### DIFF
--- a/main.go
+++ b/main.go
@@ -293,20 +293,15 @@ func commitChanges(updatedList PackageList) error {
 
 	logrus.Info("Committing changes")
 
+	iconsPath := filepath.Join(repositoryAssetsDir, "icons")
+	if _, err := wt.Add(iconsPath); err != nil {
+		return fmt.Errorf("failed to add %q to working tree: %w", iconsPath, err)
+	}
+
 	for _, packageWrapper := range updatedList {
-		assetsPath := path.Join(
-			repositoryAssetsDir,
-			packageWrapper.ParsedVendor)
-
-		chartsPath := path.Join(
-			repositoryChartsDir,
-			packageWrapper.ParsedVendor,
-			packageWrapper.Name)
-
-		packagesPath := path.Join(
-			repositoryPackagesDir,
-			packageWrapper.ParsedVendor,
-			packageWrapper.Name)
+		assetsPath := filepath.Join(repositoryAssetsDir, packageWrapper.ParsedVendor)
+		chartsPath := filepath.Join(repositoryChartsDir, packageWrapper.ParsedVendor, packageWrapper.Name)
+		packagesPath := filepath.Join(repositoryPackagesDir, packageWrapper.ParsedVendor, packageWrapper.Name)
 
 		for _, path := range []string{assetsPath, chartsPath, packagesPath} {
 			if _, err := wt.Add(path); err != nil {

--- a/main.go
+++ b/main.go
@@ -277,7 +277,7 @@ func gitCleanup() error {
 }
 
 // Commits changes to index file, assets, charts, and packages
-func commitChanges(updatedList PackageList, iconOverride bool) error {
+func commitChanges(updatedList PackageList) error {
 	var additions, updates string
 	commitOptions := git.CommitOptions{}
 
@@ -334,9 +334,6 @@ func commitChanges(updatedList PackageList, iconOverride bool) error {
 		return fmt.Errorf("failed to add %q to working tree: %w", indexFile, err)
 	}
 	commitMessage := "Charts CI\n```"
-	if iconOverride {
-		commitMessage = "Icon Override CI\n```"
-	}
 	sort.Sort(updatedList)
 	for _, packageWrapper := range updatedList {
 		lineItem := fmt.Sprintf("  %s/%s:\n",
@@ -1154,7 +1151,7 @@ func generateChanges(auto bool) {
 	}
 
 	if auto {
-		err = commitChanges(packageList, false)
+		err = commitChanges(packageList)
 		if err != nil {
 			logrus.Fatal(err)
 		}


### PR DESCRIPTION
When the icons code was introduced, we never modified `commitChanges` to add `assets/icons`. There is a condition in `commitChanges` that causes `partner-charts-ci` to exit with a non-zero code when there are changes left over after the commit in the git working tree. So when `assets/icons` was being changed, `partner-charts-ci auto` was failing because `assets/icons` was not being included in the commit.

This only became a problem recently because we [added the Airlock charts](https://github.com/rancher/partner-charts/pull/1035), which didn't have icons files yet.