### PR TITLE
Fix `icons.detectMIMEType`

### DIFF
--- a/pkg/icons/icons.go
+++ b/pkg/icons/icons.go
@@ -43,7 +43,7 @@ func EnsureIconDownloaded(iconUrl, packageName string) (string, error) {
 
 	ext := filepath.Ext(iconUrl)
 	if ext == "" {
-		ext = detectMIMEType(resp.Body)
+		ext = getExtension(resp.Body)
 		if ext == "" {
 			return "", fmt.Errorf("failed to get file extension: %w", err)
 		}
@@ -77,7 +77,7 @@ func Exists(filePath string) bool {
 	return false // File might not exist
 }
 
-func detectMIMEType(body io.ReadCloser) string {
+func getExtension(body io.ReadCloser) string {
 	buffer := make([]byte, 512)
 	_, err := body.Read(buffer)
 	if err != nil {

--- a/pkg/icons/icons.go
+++ b/pkg/icons/icons.go
@@ -40,6 +40,9 @@ func EnsureIconDownloaded(iconUrl, packageName string) (string, error) {
 		return "", fmt.Errorf("failed to http get %q: %w", iconUrl, err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("got non-2xx status code on response: %s", resp.Status)
+	}
 
 	contents, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
The code that downloads icon files uses a function called `detectMIMEType()` (now called `getExtension()`) to detect what the extension of the icon file will be. This function had a serious bug. Whenever it ran, it read the first 512 bytes of the response body in order to determine what the file extension should be. But when you read data from an `io.Reader`, you can never get that data back. So when we read the rest of the body in `EnsureIconDownloaded()`, we only put the data that came after the first 512 bytes. That means we get a useless image file.

This only happened when we could not get the extension from the URL, because if we could, we never called `detectMIMEType()`/`getExtension()`.