### PR TITLE
Update `cull` subcommand

### DIFF
--- a/main.go
+++ b/main.go
@@ -1365,6 +1365,9 @@ func validateRepo(c *cli.Context) {
 
 }
 
+// cullCharts removes chart versions that are older than the passed number of
+// days. Like many other subcommands, the PACKAGE environment variable can be
+// used to work on a single package.
 func cullCharts(c *cli.Context) error {
 	currentPackage := os.Getenv(packageEnvVariable)
 	packageWrappers, err := listPackageWrappers(currentPackage)

--- a/main.go
+++ b/main.go
@@ -127,9 +127,8 @@ func (packageWrapper *PackageWrapper) FullName() string {
 }
 
 // Populates PackageWrapper with relevant data from upstream and
-// checks for updates. If onlyLatest is true, then it puts only the
-// latest upstream chart version in PackageWrapper.FetchVersions.
-// Returns true if newer package version is available.
+// checks for updates. Returns true if newer package version is
+// available.
 func (packageWrapper *PackageWrapper) Populate() (bool, error) {
 	sourceMetadata, err := fetcher.FetchUpstream(*packageWrapper.UpstreamYaml)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -209,7 +209,7 @@ func annotate(vendor, chartName, annotation, value string, remove, onlyLatest bo
 		}
 	}
 
-	if err := writeCharts(vendor, chartName, existingCharts); err != nil {
+	if err := writeCharts(paths.GetRepoRoot(), vendor, chartName, existingCharts); err != nil {
 		return fmt.Errorf("failed to write charts: %w", err)
 	}
 
@@ -524,7 +524,7 @@ func ApplyUpdates(packageWrapper PackageWrapper) error {
 	allCharts := make([]*ChartWrapper, 0, len(existingCharts)+len(newCharts))
 	allCharts = append(allCharts, existingCharts...)
 	allCharts = append(allCharts, newCharts...)
-	if err := writeCharts(packageWrapper.ParsedVendor, packageWrapper.Name, allCharts); err != nil {
+	if err := writeCharts(paths.GetRepoRoot(), packageWrapper.ParsedVendor, packageWrapper.Name, allCharts); err != nil {
 		return fmt.Errorf("failed to write charts: %w", err)
 	}
 
@@ -542,9 +542,9 @@ func getTgzFilename(helmChart *chart.Chart) string {
 // packages passed in chartWrappers. In other words, charts that are
 // not in chartWrappers are deleted, and charts from chartWrappers
 // that are modified or do not exist on disk are written.
-func writeCharts(vendor, chartName string, chartWrappers []*ChartWrapper) error {
-	chartsDir := filepath.Join(paths.GetRepoRoot(), repositoryChartsDir, vendor, chartName)
-	assetsDir := filepath.Join(paths.GetRepoRoot(), repositoryAssetsDir, vendor)
+func writeCharts(repoRoot, vendor, chartName string, chartWrappers []*ChartWrapper) error {
+	chartsDir := filepath.Join(repoRoot, repositoryChartsDir, vendor, chartName)
+	assetsDir := filepath.Join(repoRoot, repositoryAssetsDir, vendor)
 
 	if err := os.RemoveAll(chartsDir); err != nil {
 		return fmt.Errorf("failed to wipe existing charts directory: %w", err)


### PR DESCRIPTION
In https://github.com/rancher/partner-charts-ci/pull/13 I changed the way `partner-charts-ci` works. Specifically, I changed the layout of the `charts/` directory. The `cull` subcommand was never updated - this PR brings its operation into alignment with the changes in https://github.com/rancher/partner-charts-ci/pull/13.