### PR TITLE
Remove unused functions

### DIFF
--- a/pkg/conform/conform.go
+++ b/pkg/conform/conform.go
@@ -129,17 +129,6 @@ func ApplyChartAnnotations(helmChart *chart.Chart, annotations map[string]string
 
 }
 
-func RemoveChartAnnotations(helmChart *chart.Chart, annotations map[string]string) bool {
-	modified := false
-	for annotation, value := range annotations {
-		if DeannotateChart(helmChart, annotation, value) {
-			modified = true
-		}
-	}
-
-	return modified
-}
-
 func StripPackageVersion(chartVersion string) string {
 	version, err := semver.NewVersion(chartVersion)
 	if err != nil {

--- a/pkg/conform/export.go
+++ b/pkg/conform/export.go
@@ -9,150 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 )
-
-const (
-	overlayDir   = "overlay"
-	generatedDir = "generated-changes"
-)
-
-func GetFileList(searchPath string, relative bool) ([]string, []string, error) {
-	fileList := make([]string, 0)
-	dirList := make([]string, 0)
-	walkFunc := func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		filePath := path
-		if relative {
-			filePath, err = filepath.Rel(searchPath, path)
-			if err != nil {
-				return err
-			}
-		}
-		if info.IsDir() && path != searchPath {
-			dirList = append(dirList, filePath)
-		} else if !info.IsDir() {
-			fileList = append(fileList, filePath)
-		}
-
-		return nil
-	}
-
-	err := filepath.Walk(searchPath, walkFunc)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return dirList, fileList, nil
-}
-
-func ApplyOverlayFiles(packagePath string) error {
-	overlayPath := filepath.Join(packagePath, overlayDir)
-	if _, err := os.Stat(overlayPath); !os.IsNotExist(err) {
-		dirList, fileList, err := GetFileList(overlayPath, true)
-		if err != nil {
-			return err
-		}
-		if len(dirList) == 0 {
-			dirList = append(dirList, "")
-		}
-		for _, dir := range dirList {
-			generatedPath := filepath.Join(packagePath, "charts", dir)
-			if err := os.MkdirAll(generatedPath, 0755); err != nil {
-				return fmt.Errorf("failed to mkdir %q: %w", generatedPath, err)
-			}
-		}
-
-		for _, filePath := range fileList {
-			srcPath := filepath.Join(overlayPath, filePath)
-			srcFile, err := os.Open(srcPath)
-			if err != nil {
-				return fmt.Errorf("failed to open %q: %w", srcPath, err)
-			}
-			defer srcFile.Close()
-
-			generatedPath := filepath.Join(packagePath, "charts", filePath)
-			if _, err := os.Stat(generatedPath); !os.IsNotExist(err) {
-				logrus.Warnf("Replacing %s with overlay file", filePath)
-				err = os.Remove(generatedPath)
-				if err != nil {
-					return err
-				}
-			}
-			dstFile, err := os.Create(generatedPath)
-			if err != nil {
-				return err
-			}
-			defer dstFile.Close()
-
-			if _, err = io.Copy(dstFile, srcFile); err != nil {
-				return err
-			}
-		}
-
-	}
-
-	return nil
-
-}
-
-func LinkOverlayFiles(packagePath string) error {
-	overlayPath := filepath.Join(packagePath, overlayDir)
-	if _, err := os.Stat(overlayPath); !os.IsNotExist(err) {
-		dirList, fileList, err := GetFileList(overlayPath, true)
-		if err != nil {
-			return err
-		}
-		if len(dirList) == 0 {
-			dirList = append(dirList, "")
-		}
-		for _, dir := range dirList {
-			generatedPath := filepath.Join(packagePath, generatedDir, overlayDir, dir)
-			if err := os.MkdirAll(generatedPath, 0755); err != nil {
-				return fmt.Errorf("failed to mkdir %q: %w", generatedPath, err)
-			}
-		}
-
-		for _, file := range fileList {
-			depth := len(strings.Split(file, "/")) + 1
-			pathPrefix := strings.Repeat("../", depth)
-			generatedPath := filepath.Join(packagePath, generatedDir, overlayDir, file)
-			if err := os.RemoveAll(generatedPath); err != nil {
-				logrus.Errorf("failed to remove %q: %s", generatedPath, err)
-			}
-			symLinkPath := filepath.Join(pathPrefix, overlayDir, file)
-			err = os.Symlink(symLinkPath, generatedPath)
-			if err != nil {
-				logrus.Error(err)
-			}
-		}
-
-	}
-
-	return nil
-}
-
-func RemoveOverlayFiles(packagePath string) error {
-	overlayPath := filepath.Join(packagePath, overlayDir)
-	if _, err := os.Stat(overlayPath); !os.IsNotExist(err) {
-		_, fileList, err := GetFileList(overlayPath, true)
-		if err != nil {
-			return err
-		}
-		for _, file := range fileList {
-			generatedPath := filepath.Join(packagePath, generatedDir, overlayDir, file)
-			if err := os.RemoveAll(generatedPath); err != nil {
-				logrus.Errorf("failed to remove %q: %s", generatedPath, err)
-			}
-		}
-	}
-
-	return nil
-}
 
 func ExportChartDirectory(chart *chart.Chart, targetPath string) error {
 	wd, err := os.Getwd()
@@ -185,18 +44,6 @@ func ExportChartDirectory(chart *chart.Chart, targetPath string) error {
 
 	if err = os.Rename(chartOutputPath, targetPath); err != nil {
 		return fmt.Errorf("failed to move %q to %q: %w", chartOutputPath, targetPath, err)
-	}
-
-	return nil
-}
-
-func ExportDependenciesToDirectory(chart *chart.Chart, targetPath string) error {
-	for _, c := range chart.Dependencies() {
-		logrus.Debugf("Saving dependency %s to %s\n", c.Name(), targetPath)
-		err := chartutil.SaveDir(c, targetPath)
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -3,7 +3,6 @@ package parse
 import (
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -37,38 +36,6 @@ type UpstreamYaml struct {
 	TrackVersions      []string       `json:"TrackVersions"`
 	ReleaseName        string         `json:"ReleaseName"`
 	Vendor             string         `json:"Vendor"`
-}
-
-func ListPackages(packageDirectory string, currentPackage string) (map[string]string, error) {
-	packageList := make(map[string]string)
-	var searchDirectory string
-
-	if currentPackage != "" {
-		searchDirectory = filepath.Join(packageDirectory, currentPackage)
-	} else {
-		searchDirectory = packageDirectory
-	}
-
-	if _, err := os.Stat(searchDirectory); os.IsNotExist(err) {
-		return packageList, err
-	}
-
-	findPackage := func(filePath string, info os.FileInfo, err error) error {
-		if err != nil {
-			logrus.Error(err)
-		}
-
-		if !info.IsDir() && info.Name() == UpstreamOptionsFile {
-			packagePath := filepath.Dir(filePath)
-			packageName := strings.TrimPrefix(packagePath, packageDirectory)
-			packageName = strings.TrimPrefix(packageName, "/")
-			packageList[packageName] = packagePath
-		}
-
-		return nil
-	}
-
-	return packageList, filepath.Walk(searchDirectory, findPackage)
 }
 
 func ParseUpstreamYaml(packagePath string) (UpstreamYaml, error) {


### PR DESCRIPTION
There are a number of functions in the `partner-charts-ci` codebase that are unused. This PR removes them in order to improve maintainability.