### PR TITLE
Rename `PackageWrapper` vendor fields to match name fields

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ type PackageWrapper struct {
 	// The package's upstream.yaml file
 	UpstreamYaml *parse.UpstreamYaml
 	// The user-facing (i.e. pretty) chart vendor name
-	Vendor string
+	DisplayVendor string
 	// The developer-facing chart vendor name
 	ParsedVendor string
 }
@@ -984,9 +984,9 @@ func listPackageWrappers(currentPackage string) (PackageList, error) {
 		packageWrapper.UpstreamYaml = &upstreamYaml
 
 		if packageWrapper.UpstreamYaml.Vendor != "" {
-			packageWrapper.Vendor = packageWrapper.UpstreamYaml.Vendor
+			packageWrapper.DisplayVendor = packageWrapper.UpstreamYaml.Vendor
 		} else {
-			packageWrapper.Vendor = packageWrapper.ParsedVendor
+			packageWrapper.DisplayVendor = packageWrapper.ParsedVendor
 		}
 
 		if packageWrapper.UpstreamYaml.DisplayName != "" {


### PR DESCRIPTION
In the PackageWrapper type, we have the following fields:
```
Name
DisplayName
Vendor
ParsedVendor
```
`Name` and `DisplayName` are as you'd expect: `Name` is the package name for programmers, log messages etc, and `DisplayName` is for displaying to the user.

`Vendor` and `ParsedVendor` are not as clear. As it turns out `Vendor` is the vendor equivalent of `DisplayName`: it is used when we want to display the "pretty" vendor name. `ParsedVendor` is the equivalent of `Name`: it is the vendor name we display in log messages and the stdout output of `partner-charts-ci`.

So, in order to make the code clearer, this pull request makes the following changes:
```
Vendor -> DisplayVendor
ParsedVendor -> Vendor
```