### PR TITLE
Add `deprecate` subcommand

### DIFF
--- a/main.go
+++ b/main.go
@@ -1460,6 +1460,26 @@ func getOlderAndNewerChartVersions(days int) (map[string][]string, map[string][]
 	return olderVersions, newerVersions, nil
 }
 
+func deprecatePackage(c *cli.Context) error {
+	if len(c.Args()) != 1 {
+		return errors.New("must provide package name as argument")
+	}
+	currentPackage := c.Args().Get(0)
+
+	packageWrappers, err := listPackageWrappers(currentPackage)
+	if err != nil {
+		return fmt.Errorf("failed to list package wrappers: %w", err)
+	}
+	packageWrapper := packageWrappers[0]
+	fmt.Println(packageWrapper)
+
+	// set Deprecated: true in upstream.yaml
+
+	// set deprecated: true in each chart version's Chart.yaml
+
+	return nil
+}
+
 func main() {
 	if len(os.Getenv("DEBUG")) > 0 {
 		logrus.SetLevel(logrus.DebugLevel)
@@ -1532,6 +1552,12 @@ func main() {
 			Usage:     "Remove versions of charts older than a number of days",
 			Action:    cullCharts,
 			ArgsUsage: "<days>",
+		},
+		{
+			Name:      "deprecate",
+			Usage:     "Deprecate a package and all of its charts",
+			Action:    deprecatePackage,
+			ArgsUsage: "<package>",
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -1479,7 +1479,7 @@ func deprecatePackage(c *cli.Context) error {
 
 	// set Deprecated: true in upstream.yaml
 	packageWrapper.UpstreamYaml.Deprecated = true
-	if err := parse.WriteUpstreamYaml(currentPackage, *packageWrapper.UpstreamYaml); err != nil {
+	if err := parse.WriteUpstreamYaml(packageWrapper.Path, *packageWrapper.UpstreamYaml); err != nil {
 		return fmt.Errorf("failed to write upstream.yaml: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -1049,6 +1049,11 @@ func generateChanges(auto bool) {
 
 	packageList := make(PackageList, 0, len(packageWrappers))
 	for _, packageWrapper := range packageWrappers {
+		if packageWrapper.UpstreamYaml.Deprecated {
+			logrus.Warnf("Package %s is deprecated; skipping update", packageWrapper.FullName())
+			continue
+		}
+
 		logrus.Debugf("Populating package from %s\n", packageWrapper.Path)
 		updated, err := packageWrapper.Populate()
 		if err != nil {
@@ -1483,10 +1488,10 @@ func deprecatePackage(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to load existing charts: %w", err)
 	}
-	for _, existingChart := range chartWrappers {
-		if !existingChart.Metadata.Deprecated {
-			existingChart.Metadata.Deprecated = true
-			existingChart.Modified = true
+	for _, chartWrapper := range chartWrappers {
+		if !chartWrapper.Metadata.Deprecated {
+			chartWrapper.Metadata.Deprecated = true
+			chartWrapper.Modified = true
 		}
 	}
 	if err := writeCharts(paths.GetRepoRoot(), packageWrapper.Vendor, packageWrapper.Name, chartWrappers); err != nil {

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -21,6 +21,7 @@ type UpstreamYaml struct {
 	AHRepoName         string         `json:"ArtifactHubRepo"`
 	AutoInstall        string         `json:"AutoInstall"`
 	ChartYaml          chart.Metadata `json:"ChartMetadata"`
+	Deprecated         bool           `json:"Deprecated"`
 	DisplayName        string         `json:"DisplayName"`
 	Experimental       bool           `json:"Experimental"`
 	Fetch              string         `json:"Fetch"`

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -64,5 +64,5 @@ func WriteUpstreamYaml(packagePath string, upstreamYaml UpstreamYaml) error {
 	if err := os.WriteFile(upstreamYamlPath, contents, 0o644); err != nil {
 		return fmt.Errorf("failed to write %q: %w", upstreamYamlPath, err)
 	}
-	return err
+	return nil
 }

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -1,6 +1,7 @@
 package parse
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -50,4 +51,17 @@ func ParseUpstreamYaml(packagePath string) (UpstreamYaml, error) {
 	}
 
 	return upstreamYaml, err
+}
+
+func WriteUpstreamYaml(packagePath string, upstreamYaml UpstreamYaml) error {
+	upstreamYamlPath := filepath.Join(packagePath, UpstreamOptionsFile)
+	logrus.Debugf("Attempting to write %s", upstreamYamlPath)
+	contents, err := yaml.Marshal(upstreamYaml)
+	if err != nil {
+		return fmt.Errorf("failed to marshal given UpstreamYaml to YAML: %w", err)
+	}
+	if err := os.WriteFile(upstreamYamlPath, contents, 0o644); err != nil {
+		return fmt.Errorf("failed to write %q: %w", upstreamYamlPath, err)
+	}
+	return err
 }

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -17,27 +17,27 @@ const (
 )
 
 type UpstreamYaml struct {
-	AHPackageName      string         `json:"ArtifactHubPackage"`
-	AHRepoName         string         `json:"ArtifactHubRepo"`
-	AutoInstall        string         `json:"AutoInstall"`
-	ChartYaml          chart.Metadata `json:"ChartMetadata"`
-	Deprecated         bool           `json:"Deprecated"`
-	DisplayName        string         `json:"DisplayName"`
-	Experimental       bool           `json:"Experimental"`
-	Fetch              string         `json:"Fetch"`
-	GitBranch          string         `json:"GitBranch"`
-	GitHubRelease      bool           `json:"GitHubRelease"`
-	GitRepoUrl         string         `json:"GitRepo"`
-	GitSubDirectory    string         `json:"GitSubdirectory"`
-	HelmChart          string         `json:"HelmChart"`
-	HelmRepoUrl        string         `json:"HelmRepo"`
-	Hidden             bool           `json:"Hidden"`
-	Namespace          string         `json:"Namespace"`
-	PackageVersion     int            `json:"PackageVersion"`
-	RemoteDependencies bool           `json:"RemoteDependencies"`
-	TrackVersions      []string       `json:"TrackVersions"`
-	ReleaseName        string         `json:"ReleaseName"`
-	Vendor             string         `json:"Vendor"`
+	AHPackageName      string         `json:"ArtifactHubPackage,omitempty"`
+	AHRepoName         string         `json:"ArtifactHubRepo,omitempty"`
+	AutoInstall        string         `json:"AutoInstall,omitempty"`
+	ChartYaml          chart.Metadata `json:"ChartMetadata,omitempty"`
+	Deprecated         bool           `json:"Deprecated,omitempty"`
+	DisplayName        string         `json:"DisplayName,omitempty"`
+	Experimental       bool           `json:"Experimental,omitempty"`
+	Fetch              string         `json:"Fetch,omitempty"`
+	GitBranch          string         `json:"GitBranch,omitempty"`
+	GitHubRelease      bool           `json:"GitHubRelease,omitempty"`
+	GitRepoUrl         string         `json:"GitRepo,omitempty"`
+	GitSubDirectory    string         `json:"GitSubdirectory,omitempty"`
+	HelmChart          string         `json:"HelmChart,omitempty"`
+	HelmRepoUrl        string         `json:"HelmRepo,omitempty"`
+	Hidden             bool           `json:"Hidden,omitempty"`
+	Namespace          string         `json:"Namespace,omitempty"`
+	PackageVersion     int            `json:"PackageVersion,omitempty"`
+	RemoteDependencies bool           `json:"RemoteDependencies,omitempty"`
+	TrackVersions      []string       `json:"TrackVersions,omitempty"`
+	ReleaseName        string         `json:"ReleaseName,omitempty"`
+	Vendor             string         `json:"Vendor,omitempty"`
 }
 
 func ParseUpstreamYaml(packagePath string) (UpstreamYaml, error) {


### PR DESCRIPTION
In order to give users some warning before charts are removed, we are introducing a deprecation policy. The `partner-charts-ci deprecate` command that this PR introduces is how partner charts maintainers will deprecate a chart.