### PR TITLE
Remove `RemoteDependencies` and do not modify `Dependency.Repository` when integrating new chart version

### DIFF
--- a/main.go
+++ b/main.go
@@ -719,14 +719,6 @@ func addAnnotations(packageWrapper PackageWrapper, helmChart *chart.Chart) error
 		annotations[annotationHidden] = "true"
 	}
 
-	// TODO: this is sketchy. We end up changing the repository URL of each
-	// dependency without downloading dependencies. This can't be right.
-	// And if it is, this needs a comment explaining what is going on.
-	// Need to investigate further.
-	for _, d := range helmChart.Metadata.Dependencies {
-		d.Repository = fmt.Sprintf("file://./charts/%s", d.Name)
-	}
-
 	annotations[annotationCertified] = "partner"
 
 	annotations[annotationDisplayName] = packageWrapper.DisplayName

--- a/main.go
+++ b/main.go
@@ -723,10 +723,8 @@ func addAnnotations(packageWrapper PackageWrapper, helmChart *chart.Chart) error
 	// dependency without downloading dependencies. This can't be right.
 	// And if it is, this needs a comment explaining what is going on.
 	// Need to investigate further.
-	if !packageWrapper.UpstreamYaml.RemoteDependencies {
-		for _, d := range helmChart.Metadata.Dependencies {
-			d.Repository = fmt.Sprintf("file://./charts/%s", d.Name)
-		}
+	for _, d := range helmChart.Metadata.Dependencies {
+		d.Repository = fmt.Sprintf("file://./charts/%s", d.Name)
 	}
 
 	annotations[annotationCertified] = "partner"

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -17,27 +17,26 @@ const (
 )
 
 type UpstreamYaml struct {
-	AHPackageName      string         `json:"ArtifactHubPackage,omitempty"`
-	AHRepoName         string         `json:"ArtifactHubRepo,omitempty"`
-	AutoInstall        string         `json:"AutoInstall,omitempty"`
-	ChartYaml          chart.Metadata `json:"ChartMetadata,omitempty"`
-	Deprecated         bool           `json:"Deprecated,omitempty"`
-	DisplayName        string         `json:"DisplayName,omitempty"`
-	Experimental       bool           `json:"Experimental,omitempty"`
-	Fetch              string         `json:"Fetch,omitempty"`
-	GitBranch          string         `json:"GitBranch,omitempty"`
-	GitHubRelease      bool           `json:"GitHubRelease,omitempty"`
-	GitRepoUrl         string         `json:"GitRepo,omitempty"`
-	GitSubDirectory    string         `json:"GitSubdirectory,omitempty"`
-	HelmChart          string         `json:"HelmChart,omitempty"`
-	HelmRepoUrl        string         `json:"HelmRepo,omitempty"`
-	Hidden             bool           `json:"Hidden,omitempty"`
-	Namespace          string         `json:"Namespace,omitempty"`
-	PackageVersion     int            `json:"PackageVersion,omitempty"`
-	RemoteDependencies bool           `json:"RemoteDependencies,omitempty"`
-	TrackVersions      []string       `json:"TrackVersions,omitempty"`
-	ReleaseName        string         `json:"ReleaseName,omitempty"`
-	Vendor             string         `json:"Vendor,omitempty"`
+	AHPackageName   string         `json:"ArtifactHubPackage,omitempty"`
+	AHRepoName      string         `json:"ArtifactHubRepo,omitempty"`
+	AutoInstall     string         `json:"AutoInstall,omitempty"`
+	ChartYaml       chart.Metadata `json:"ChartMetadata,omitempty"`
+	Deprecated      bool           `json:"Deprecated,omitempty"`
+	DisplayName     string         `json:"DisplayName,omitempty"`
+	Experimental    bool           `json:"Experimental,omitempty"`
+	Fetch           string         `json:"Fetch,omitempty"`
+	GitBranch       string         `json:"GitBranch,omitempty"`
+	GitHubRelease   bool           `json:"GitHubRelease,omitempty"`
+	GitRepoUrl      string         `json:"GitRepo,omitempty"`
+	GitSubDirectory string         `json:"GitSubdirectory,omitempty"`
+	HelmChart       string         `json:"HelmChart,omitempty"`
+	HelmRepoUrl     string         `json:"HelmRepo,omitempty"`
+	Hidden          bool           `json:"Hidden,omitempty"`
+	Namespace       string         `json:"Namespace,omitempty"`
+	PackageVersion  int            `json:"PackageVersion,omitempty"`
+	TrackVersions   []string       `json:"TrackVersions,omitempty"`
+	ReleaseName     string         `json:"ReleaseName,omitempty"`
+	Vendor          string         `json:"Vendor,omitempty"`
 }
 
 func ParseUpstreamYaml(packagePath string) (UpstreamYaml, error) {


### PR DESCRIPTION
There are no packages in rancher/partner-charts that currently use `RemoteDependencies`, nor do I forsee packages needing it. Accordingly this PR removes it.

This PR also makes it so that the `Dependency.Respository` field of `Chart.yaml` is no longer set to a local value when integrating new chart versions. I spent a bunch of time understanding how dependencies work in helm, and I don't think the `partner-charts-ci` code was written with this understanding. I cannot see a reason why we need this code, so this PR also removes this behavior. If we discover that we need it, we can add it back.