### PR TITLE
Set `Hidden: true` in `upstream.yaml` when hiding a chart

### DIFF
--- a/main.go
+++ b/main.go
@@ -1244,6 +1244,12 @@ func hideChart(c *cli.Context) error {
 	}
 	packageWrapper := packageWrappers[0]
 
+	// set Hidden: true in upstream.yaml
+	packageWrapper.UpstreamYaml.Hidden = true
+	if err := parse.WriteUpstreamYaml(packageWrapper.Path, *packageWrapper.UpstreamYaml); err != nil {
+		return fmt.Errorf("failed to write upstream.yaml: %w", err)
+	}
+
 	vendor := packageWrapper.Vendor
 	chartName := packageWrapper.Name
 	if err := annotate(vendor, chartName, annotationHidden, "true", false, false); err != nil {


### PR DESCRIPTION
When the user runs `partner-charts-ci hide` in order to hide a package, it does not set `Hidden: true` in the `upstream.yaml` for that package. The result of this is that the `catalog.cattle.io/hidden` annotation is not set on new chart versions from upstream when they are integrated. This PR fixes that.