### PR TITLE
Add validation and setting of defaults at parse time for `upstream.yaml`

### DIFF
--- a/main.go
+++ b/main.go
@@ -739,11 +739,7 @@ func addAnnotations(packageWrapper PackageWrapper, helmChart *chart.Chart) error
 
 	annotations[annotationDisplayName] = packageWrapper.DisplayName
 
-	if packageWrapper.UpstreamYaml.ReleaseName != "" {
-		annotations[annotationReleaseName] = packageWrapper.UpstreamYaml.ReleaseName
-	} else {
-		annotations[annotationReleaseName] = packageWrapper.Name
-	}
+	annotations[annotationReleaseName] = packageWrapper.UpstreamYaml.ReleaseName
 
 	if packageWrapper.UpstreamYaml.Namespace != "" {
 		annotations[annotationNamespace] = packageWrapper.UpstreamYaml.Namespace

--- a/main.go
+++ b/main.go
@@ -1531,7 +1531,7 @@ func deprecatePackage(c *cli.Context) error {
 
 	// set Deprecated: true in upstream.yaml
 	packageWrapper.UpstreamYaml.Deprecated = true
-	if err := upstreamyaml.WriteUpstreamYaml(packageWrapper.Path, *packageWrapper.UpstreamYaml); err != nil {
+	if err := upstreamyaml.Write(packageWrapper.Path, *packageWrapper.UpstreamYaml); err != nil {
 		return fmt.Errorf("failed to write upstream.yaml: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ const (
 	repositoryPackagesDir = "packages"
 	configOptionsFile     = "configuration.yaml"
 	featuredMax           = 5
+	upstreamYamlFile      = "upstream.yaml"
 )
 
 var (
@@ -982,7 +983,7 @@ func listPackageWrappers(currentPackage string) (PackageList, error) {
 			Name:   parts[2],
 		}
 
-		upstreamYamlPath := filepath.Join(packageWrapper.Path, "upstream.yaml")
+		upstreamYamlPath := filepath.Join(packageWrapper.Path, upstreamYamlFile)
 		upstreamYaml, err := upstreamyaml.Parse(upstreamYamlPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse upstream.yaml: %w", err)
@@ -1532,7 +1533,7 @@ func deprecatePackage(c *cli.Context) error {
 
 	// set Deprecated: true in upstream.yaml
 	packageWrapper.UpstreamYaml.Deprecated = true
-	upstreamYamlPath := filepath.Join(packageWrapper.Path, "upstream.yaml")
+	upstreamYamlPath := filepath.Join(packageWrapper.Path, upstreamYamlFile)
 	if err := upstreamyaml.Write(upstreamYamlPath, *packageWrapper.UpstreamYaml); err != nil {
 		return fmt.Errorf("failed to write upstream.yaml: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -982,7 +982,8 @@ func listPackageWrappers(currentPackage string) (PackageList, error) {
 			Name:   parts[2],
 		}
 
-		upstreamYaml, err := upstreamyaml.Parse(packageWrapper.Path)
+		upstreamYamlPath := filepath.Join(packageWrapper.Path, "upstream.yaml")
+		upstreamYaml, err := upstreamyaml.Parse(upstreamYamlPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse upstream.yaml: %w", err)
 		}
@@ -1531,7 +1532,8 @@ func deprecatePackage(c *cli.Context) error {
 
 	// set Deprecated: true in upstream.yaml
 	packageWrapper.UpstreamYaml.Deprecated = true
-	if err := upstreamyaml.Write(packageWrapper.Path, *packageWrapper.UpstreamYaml); err != nil {
+	upstreamYamlPath := filepath.Join(packageWrapper.Path, "upstream.yaml")
+	if err := upstreamyaml.Write(upstreamYamlPath, *packageWrapper.UpstreamYaml); err != nil {
 		return fmt.Errorf("failed to write upstream.yaml: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -988,7 +988,7 @@ func listPackageWrappers(currentPackage string) (PackageList, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse upstream.yaml: %w", err)
 		}
-		packageWrapper.UpstreamYaml = &upstreamYaml
+		packageWrapper.UpstreamYaml = upstreamYaml
 
 		if packageWrapper.UpstreamYaml.Vendor != "" {
 			packageWrapper.DisplayVendor = packageWrapper.UpstreamYaml.Vendor

--- a/main.go
+++ b/main.go
@@ -662,7 +662,7 @@ func integrateCharts(packageWrapper PackageWrapper, existingCharts, newCharts []
 		if err := applyOverlayFiles(overlayFiles, newChart.Chart); err != nil {
 			return fmt.Errorf("failed to apply overlay files to chart %q version %q: %w", newChart.Name(), newChart.Metadata.Version, err)
 		}
-		conform.OverlayChartMetadata(newChart.Chart, packageWrapper.UpstreamYaml.ChartYaml)
+		conform.OverlayChartMetadata(newChart.Chart, packageWrapper.UpstreamYaml.ChartMetadata)
 		if err := addAnnotations(packageWrapper, newChart.Chart); err != nil {
 			return fmt.Errorf("failed to add annotations to chart %q version %q: %w", newChart.Name(), newChart.Metadata.Version, err)
 		}
@@ -745,8 +745,8 @@ func addAnnotations(packageWrapper PackageWrapper, helmChart *chart.Chart) error
 		annotations[annotationNamespace] = packageWrapper.UpstreamYaml.Namespace
 	}
 
-	if packageWrapper.UpstreamYaml.ChartYaml.KubeVersion != "" {
-		annotations[annotationKubeVersion] = packageWrapper.UpstreamYaml.ChartYaml.KubeVersion
+	if packageWrapper.UpstreamYaml.ChartMetadata.KubeVersion != "" {
+		annotations[annotationKubeVersion] = packageWrapper.UpstreamYaml.ChartMetadata.KubeVersion
 	} else if helmChart.Metadata.KubeVersion != "" {
 		annotations[annotationKubeVersion] = helmChart.Metadata.KubeVersion
 	}

--- a/main.go
+++ b/main.go
@@ -18,8 +18,8 @@ import (
 	"github.com/rancher/partner-charts-ci/pkg/conform"
 	"github.com/rancher/partner-charts-ci/pkg/fetcher"
 	"github.com/rancher/partner-charts-ci/pkg/icons"
-	"github.com/rancher/partner-charts-ci/pkg/parse"
 	"github.com/rancher/partner-charts-ci/pkg/paths"
+	"github.com/rancher/partner-charts-ci/pkg/upstreamyaml"
 	"github.com/rancher/partner-charts-ci/pkg/validate"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -95,7 +95,7 @@ type PackageWrapper struct {
 	// SourceMetadata represents metadata fetched from the upstream repository
 	SourceMetadata *fetcher.ChartSourceMetadata
 	// The package's upstream.yaml file
-	UpstreamYaml *parse.UpstreamYaml
+	UpstreamYaml *upstreamyaml.UpstreamYaml
 	// The user-facing (i.e. pretty) chart vendor name
 	DisplayVendor string
 	// The developer-facing chart vendor name
@@ -982,7 +982,7 @@ func listPackageWrappers(currentPackage string) (PackageList, error) {
 			Name:   parts[2],
 		}
 
-		upstreamYaml, err := parse.ParseUpstreamYaml(packageWrapper.Path)
+		upstreamYaml, err := upstreamyaml.ParseUpstreamYaml(packageWrapper.Path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse upstream.yaml: %w", err)
 		}
@@ -1531,7 +1531,7 @@ func deprecatePackage(c *cli.Context) error {
 
 	// set Deprecated: true in upstream.yaml
 	packageWrapper.UpstreamYaml.Deprecated = true
-	if err := parse.WriteUpstreamYaml(packageWrapper.Path, *packageWrapper.UpstreamYaml); err != nil {
+	if err := upstreamyaml.WriteUpstreamYaml(packageWrapper.Path, *packageWrapper.UpstreamYaml); err != nil {
 		return fmt.Errorf("failed to write upstream.yaml: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -982,7 +982,7 @@ func listPackageWrappers(currentPackage string) (PackageList, error) {
 			Name:   parts[2],
 		}
 
-		upstreamYaml, err := upstreamyaml.ParseUpstreamYaml(packageWrapper.Path)
+		upstreamYaml, err := upstreamyaml.Parse(packageWrapper.Path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse upstream.yaml: %w", err)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -264,7 +264,7 @@ func TestMain(t *testing.T) {
 			for _, testCase := range testCases {
 				packageWrapper := PackageWrapper{
 					UpstreamYaml: &upstreamyaml.UpstreamYaml{
-						ChartYaml: chart.Metadata{
+						ChartMetadata: chart.Metadata{
 							KubeVersion: testCase.UpstreamYamlKubeVersion,
 						},
 					},

--- a/main_test.go
+++ b/main_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/rancher/partner-charts-ci/pkg/parse"
+	"github.com/rancher/partner-charts-ci/pkg/upstreamyaml"
 	"github.com/stretchr/testify/assert"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -89,7 +89,7 @@ func TestMain(t *testing.T) {
 		t.Run("should set auto-install annotation properly", func(t *testing.T) {
 			for _, autoInstall := range []string{"", "some-chart"} {
 				packageWrapper := PackageWrapper{
-					UpstreamYaml: &parse.UpstreamYaml{
+					UpstreamYaml: &upstreamyaml.UpstreamYaml{
 						AutoInstall: autoInstall,
 					},
 				}
@@ -112,7 +112,7 @@ func TestMain(t *testing.T) {
 		t.Run("should set experimental annotation properly", func(t *testing.T) {
 			for _, experimental := range []bool{false, true} {
 				packageWrapper := PackageWrapper{
-					UpstreamYaml: &parse.UpstreamYaml{
+					UpstreamYaml: &upstreamyaml.UpstreamYaml{
 						Experimental: experimental,
 					},
 				}
@@ -135,7 +135,7 @@ func TestMain(t *testing.T) {
 		t.Run("should set hidden annotation properly", func(t *testing.T) {
 			for _, hidden := range []bool{false, true} {
 				packageWrapper := PackageWrapper{
-					UpstreamYaml: &parse.UpstreamYaml{
+					UpstreamYaml: &upstreamyaml.UpstreamYaml{
 						Hidden: hidden,
 					},
 				}
@@ -157,7 +157,7 @@ func TestMain(t *testing.T) {
 
 		t.Run("should always set certified annotation", func(t *testing.T) {
 			packageWrapper := PackageWrapper{
-				UpstreamYaml: &parse.UpstreamYaml{},
+				UpstreamYaml: &upstreamyaml.UpstreamYaml{},
 			}
 			helmChart := &chart.Chart{
 				Metadata: &chart.Metadata{
@@ -176,7 +176,7 @@ func TestMain(t *testing.T) {
 			displayName := "Display Name"
 			packageWrapper := PackageWrapper{
 				DisplayName:  displayName,
-				UpstreamYaml: &parse.UpstreamYaml{},
+				UpstreamYaml: &upstreamyaml.UpstreamYaml{},
 			}
 			helmChart := &chart.Chart{
 				Metadata: &chart.Metadata{
@@ -211,7 +211,7 @@ func TestMain(t *testing.T) {
 			for _, testCase := range testCases {
 				packageWrapper := PackageWrapper{
 					Name: testCase.PackageWrapperName,
-					UpstreamYaml: &parse.UpstreamYaml{
+					UpstreamYaml: &upstreamyaml.UpstreamYaml{
 						ReleaseName: testCase.UpstreamYamlName,
 					},
 				}
@@ -236,7 +236,7 @@ func TestMain(t *testing.T) {
 		t.Run("should set namespace annotation properly", func(t *testing.T) {
 			for _, namespace := range []string{"", "test-namespace"} {
 				packageWrapper := PackageWrapper{
-					UpstreamYaml: &parse.UpstreamYaml{
+					UpstreamYaml: &upstreamyaml.UpstreamYaml{
 						Namespace: namespace,
 					},
 				}
@@ -285,7 +285,7 @@ func TestMain(t *testing.T) {
 			}
 			for _, testCase := range testCases {
 				packageWrapper := PackageWrapper{
-					UpstreamYaml: &parse.UpstreamYaml{
+					UpstreamYaml: &upstreamyaml.UpstreamYaml{
 						ChartYaml: chart.Metadata{
 							KubeVersion: testCase.UpstreamYamlKubeVersion,
 						},

--- a/main_test.go
+++ b/main_test.go
@@ -192,45 +192,23 @@ func TestMain(t *testing.T) {
 		})
 
 		t.Run("should set release-name annotation properly", func(t *testing.T) {
-			testCases := []struct {
-				PackageWrapperName       string
-				UpstreamYamlName         string
-				ShouldBeUpstreamYamlName bool
-			}{
-				{
-					PackageWrapperName:       "packageWrapperName",
-					UpstreamYamlName:         "upstreamYamlName",
-					ShouldBeUpstreamYamlName: true,
-				},
-				{
-					PackageWrapperName:       "packageWrapperName",
-					UpstreamYamlName:         "",
-					ShouldBeUpstreamYamlName: false,
+			releaseName := "Release Name"
+			packageWrapper := PackageWrapper{
+				UpstreamYaml: &upstreamyaml.UpstreamYaml{
+					ReleaseName: releaseName,
 				},
 			}
-			for _, testCase := range testCases {
-				packageWrapper := PackageWrapper{
-					Name: testCase.PackageWrapperName,
-					UpstreamYaml: &upstreamyaml.UpstreamYaml{
-						ReleaseName: testCase.UpstreamYamlName,
-					},
-				}
-				helmChart := &chart.Chart{
-					Metadata: &chart.Metadata{
-						Dependencies: []*chart.Dependency{},
-					},
-				}
-				if err := addAnnotations(packageWrapper, helmChart); err != nil {
-					t.Fatalf("unexpected error: %s", err)
-				}
-				value, ok := helmChart.Metadata.Annotations[annotationReleaseName]
-				assert.True(t, ok)
-				if testCase.ShouldBeUpstreamYamlName {
-					assert.Equal(t, testCase.UpstreamYamlName, value)
-				} else {
-					assert.Equal(t, testCase.PackageWrapperName, value)
-				}
+			helmChart := &chart.Chart{
+				Metadata: &chart.Metadata{
+					Dependencies: []*chart.Dependency{},
+				},
 			}
+			if err := addAnnotations(packageWrapper, helmChart); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			value, ok := helmChart.Metadata.Annotations[annotationReleaseName]
+			assert.True(t, ok)
+			assert.Equal(t, releaseName, value)
 		})
 
 		t.Run("should set namespace annotation properly", func(t *testing.T) {

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -97,7 +97,7 @@ func fetchUpstreamHelmrepo(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceM
 
 // Constructs Chart Metadata for latest version published to ArtifactHub
 func fetchUpstreamArtifacthub(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata, error) {
-	url := fmt.Sprintf("%s/%s/%s", artifactHubApi, upstreamYaml.AHRepoName, upstreamYaml.ArtifactHubPackage)
+	url := fmt.Sprintf("%s/%s/%s", artifactHubApi, upstreamYaml.ArtifactHubRepo, upstreamYaml.ArtifactHubPackage)
 
 	apiResp := ArtifactHubApiHelm{}
 
@@ -117,7 +117,7 @@ func fetchUpstreamArtifacthub(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSour
 	}
 
 	if apiResp.ContentUrl == "" {
-		return ChartSourceMetadata{}, fmt.Errorf("ArtifactHub package: %s/%s not found", upstreamYaml.AHRepoName, upstreamYaml.ArtifactHubPackage)
+		return ChartSourceMetadata{}, fmt.Errorf("ArtifactHub package: %s/%s not found", upstreamYaml.ArtifactHubRepo, upstreamYaml.ArtifactHubPackage)
 	}
 
 	upstreamYaml.HelmRepoUrl = apiResp.Repository.Url
@@ -308,7 +308,7 @@ func fetchUpstreamGit(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetada
 func FetchUpstream(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata, error) {
 	var err error
 	chartSourceMetadata := ChartSourceMetadata{}
-	if upstreamYaml.AHRepoName != "" && upstreamYaml.ArtifactHubPackage != "" {
+	if upstreamYaml.ArtifactHubRepo != "" && upstreamYaml.ArtifactHubPackage != "" {
 		chartSourceMetadata, err = fetchUpstreamArtifacthub(upstreamYaml)
 	} else if upstreamYaml.HelmRepoUrl != "" && upstreamYaml.HelmChart != "" {
 		chartSourceMetadata, err = fetchUpstreamHelmrepo(upstreamYaml)

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -97,7 +97,7 @@ func fetchUpstreamHelmrepo(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceM
 
 // Constructs Chart Metadata for latest version published to ArtifactHub
 func fetchUpstreamArtifacthub(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata, error) {
-	url := fmt.Sprintf("%s/%s/%s", artifactHubApi, upstreamYaml.AHRepoName, upstreamYaml.AHPackageName)
+	url := fmt.Sprintf("%s/%s/%s", artifactHubApi, upstreamYaml.AHRepoName, upstreamYaml.ArtifactHubPackage)
 
 	apiResp := ArtifactHubApiHelm{}
 
@@ -117,7 +117,7 @@ func fetchUpstreamArtifacthub(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSour
 	}
 
 	if apiResp.ContentUrl == "" {
-		return ChartSourceMetadata{}, fmt.Errorf("ArtifactHub package: %s/%s not found", upstreamYaml.AHRepoName, upstreamYaml.AHPackageName)
+		return ChartSourceMetadata{}, fmt.Errorf("ArtifactHub package: %s/%s not found", upstreamYaml.AHRepoName, upstreamYaml.ArtifactHubPackage)
 	}
 
 	upstreamYaml.HelmRepoUrl = apiResp.Repository.Url
@@ -308,7 +308,7 @@ func fetchUpstreamGit(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetada
 func FetchUpstream(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata, error) {
 	var err error
 	chartSourceMetadata := ChartSourceMetadata{}
-	if upstreamYaml.AHRepoName != "" && upstreamYaml.AHPackageName != "" {
+	if upstreamYaml.AHRepoName != "" && upstreamYaml.ArtifactHubPackage != "" {
 		chartSourceMetadata, err = fetchUpstreamArtifacthub(upstreamYaml)
 	} else if upstreamYaml.HelmRepoUrl != "" && upstreamYaml.HelmChart != "" {
 		chartSourceMetadata, err = fetchUpstreamHelmrepo(upstreamYaml)

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -15,7 +15,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/go-github/v53/github"
-	"github.com/rancher/partner-charts-ci/pkg/parse"
+	"github.com/rancher/partner-charts-ci/pkg/upstreamyaml"
 	"github.com/sirupsen/logrus"
 
 	"helm.sh/helm/v3/pkg/chart"
@@ -49,7 +49,7 @@ type ChartSourceMetadata struct {
 }
 
 // Constructs Chart Metadata for latest version published to Helm Repository
-func fetchUpstreamHelmrepo(upstreamYaml parse.UpstreamYaml) (ChartSourceMetadata, error) {
+func fetchUpstreamHelmrepo(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata, error) {
 	upstreamYaml.HelmRepoUrl = strings.TrimSuffix(upstreamYaml.HelmRepoUrl, "/")
 	url := fmt.Sprintf("%s/index.yaml", upstreamYaml.HelmRepoUrl)
 
@@ -96,7 +96,7 @@ func fetchUpstreamHelmrepo(upstreamYaml parse.UpstreamYaml) (ChartSourceMetadata
 }
 
 // Constructs Chart Metadata for latest version published to ArtifactHub
-func fetchUpstreamArtifacthub(upstreamYaml parse.UpstreamYaml) (ChartSourceMetadata, error) {
+func fetchUpstreamArtifacthub(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata, error) {
 	url := fmt.Sprintf("%s/%s/%s", artifactHubApi, upstreamYaml.AHRepoName, upstreamYaml.AHPackageName)
 
 	apiResp := ArtifactHubApiHelm{}
@@ -235,7 +235,7 @@ func gitCheckoutCommit(path, commit string) error {
 }
 
 // Constructs Chart Metadata for latest version published to Git Repository
-func fetchUpstreamGit(upstreamYaml parse.UpstreamYaml) (ChartSourceMetadata, error) {
+func fetchUpstreamGit(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata, error) {
 	var upstreamCommit string
 
 	clonePath, err := gitCloneToDirectory(upstreamYaml.GitRepoUrl, upstreamYaml.GitBranch, !upstreamYaml.GitHubRelease)
@@ -305,7 +305,7 @@ func fetchUpstreamGit(upstreamYaml parse.UpstreamYaml) (ChartSourceMetadata, err
 	return chartSourceMeta, nil
 }
 
-func FetchUpstream(upstreamYaml parse.UpstreamYaml) (ChartSourceMetadata, error) {
+func FetchUpstream(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata, error) {
 	var err error
 	chartSourceMetadata := ChartSourceMetadata{}
 	if upstreamYaml.AHRepoName != "" && upstreamYaml.AHPackageName != "" {

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -50,8 +50,8 @@ type ChartSourceMetadata struct {
 
 // Constructs Chart Metadata for latest version published to Helm Repository
 func fetchUpstreamHelmrepo(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata, error) {
-	upstreamYaml.HelmRepoUrl = strings.TrimSuffix(upstreamYaml.HelmRepoUrl, "/")
-	url := fmt.Sprintf("%s/index.yaml", upstreamYaml.HelmRepoUrl)
+	upstreamYaml.HelmRepo = strings.TrimSuffix(upstreamYaml.HelmRepo, "/")
+	url := fmt.Sprintf("%s/index.yaml", upstreamYaml.HelmRepo)
 
 	indexYaml := repo.NewIndexFile()
 	chartSourceMeta := ChartSourceMetadata{}
@@ -77,7 +77,7 @@ func fetchUpstreamHelmrepo(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceM
 		return chartSourceMeta, err
 	}
 	if _, ok := indexYaml.Entries[upstreamYaml.HelmChart]; !ok {
-		return chartSourceMeta, fmt.Errorf("Helm chart: %s/%s not found", upstreamYaml.HelmRepoUrl, upstreamYaml.HelmChart)
+		return chartSourceMeta, fmt.Errorf("Helm chart: %s/%s not found", upstreamYaml.HelmRepo, upstreamYaml.HelmChart)
 	}
 
 	indexYaml.SortEntries()
@@ -86,7 +86,7 @@ func fetchUpstreamHelmrepo(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceM
 	for i := range upstreamVersions {
 		chartUrl := upstreamVersions[i].URLs[0]
 		if !strings.HasPrefix(chartUrl, "http") {
-			upstreamVersions[i].URLs[0] = upstreamYaml.HelmRepoUrl + "/" + chartUrl
+			upstreamVersions[i].URLs[0] = upstreamYaml.HelmRepo + "/" + chartUrl
 		}
 	}
 
@@ -120,7 +120,7 @@ func fetchUpstreamArtifacthub(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSour
 		return ChartSourceMetadata{}, fmt.Errorf("ArtifactHub package: %s/%s not found", upstreamYaml.ArtifactHubRepo, upstreamYaml.ArtifactHubPackage)
 	}
 
-	upstreamYaml.HelmRepoUrl = apiResp.Repository.Url
+	upstreamYaml.HelmRepo = apiResp.Repository.Url
 	upstreamYaml.HelmChart = apiResp.Name
 
 	chartSourceMeta, err := fetchUpstreamHelmrepo(upstreamYaml)
@@ -310,7 +310,7 @@ func FetchUpstream(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata,
 	chartSourceMetadata := ChartSourceMetadata{}
 	if upstreamYaml.ArtifactHubRepo != "" && upstreamYaml.ArtifactHubPackage != "" {
 		chartSourceMetadata, err = fetchUpstreamArtifacthub(upstreamYaml)
-	} else if upstreamYaml.HelmRepoUrl != "" && upstreamYaml.HelmChart != "" {
+	} else if upstreamYaml.HelmRepo != "" && upstreamYaml.HelmChart != "" {
 		chartSourceMetadata, err = fetchUpstreamHelmrepo(upstreamYaml)
 	} else if upstreamYaml.GitRepo != "" {
 		chartSourceMetadata, err = fetchUpstreamGit(upstreamYaml)

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -270,10 +270,10 @@ func fetchUpstreamGit(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetada
 	}
 
 	chartPath := clonePath
-	if upstreamYaml.GitSubDirectory != "" {
-		chartPath = filepath.Join(clonePath, upstreamYaml.GitSubDirectory)
+	if upstreamYaml.GitSubdirectory != "" {
+		chartPath = filepath.Join(clonePath, upstreamYaml.GitSubdirectory)
 		if _, err := os.Stat(chartPath); os.IsNotExist(err) {
-			err = fmt.Errorf("git subdirectory '%s' does not exist", upstreamYaml.GitSubDirectory)
+			err = fmt.Errorf("git subdirectory '%s' does not exist", upstreamYaml.GitSubdirectory)
 			return ChartSourceMetadata{}, err
 		}
 	}
@@ -293,7 +293,7 @@ func fetchUpstreamGit(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetada
 	chartSourceMeta := ChartSourceMetadata{
 		Commit:       upstreamCommit,
 		Source:       "Git",
-		SubDirectory: upstreamYaml.GitSubDirectory,
+		SubDirectory: upstreamYaml.GitSubdirectory,
 		Versions:     versions,
 	}
 

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -238,14 +238,14 @@ func gitCheckoutCommit(path, commit string) error {
 func fetchUpstreamGit(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata, error) {
 	var upstreamCommit string
 
-	clonePath, err := gitCloneToDirectory(upstreamYaml.GitRepoUrl, upstreamYaml.GitBranch, !upstreamYaml.GitHubRelease)
+	clonePath, err := gitCloneToDirectory(upstreamYaml.GitRepo, upstreamYaml.GitBranch, !upstreamYaml.GitHubRelease)
 	if err != nil {
 		return ChartSourceMetadata{}, err
 	}
 
 	if upstreamYaml.GitHubRelease {
 		logrus.Debug("Fetching GitHub Release")
-		upstreamCommit, err = fetchGitHubRelease(upstreamYaml.GitRepoUrl)
+		upstreamCommit, err = fetchGitHubRelease(upstreamYaml.GitRepo)
 		if err != nil {
 			return ChartSourceMetadata{}, err
 		}
@@ -285,7 +285,7 @@ func fetchUpstreamGit(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetada
 
 	version := repo.ChartVersion{
 		Metadata: helmChart.Metadata,
-		URLs:     []string{upstreamYaml.GitRepoUrl},
+		URLs:     []string{upstreamYaml.GitRepo},
 	}
 
 	versions := repo.ChartVersions{&version}
@@ -312,7 +312,7 @@ func FetchUpstream(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata,
 		chartSourceMetadata, err = fetchUpstreamArtifacthub(upstreamYaml)
 	} else if upstreamYaml.HelmRepoUrl != "" && upstreamYaml.HelmChart != "" {
 		chartSourceMetadata, err = fetchUpstreamHelmrepo(upstreamYaml)
-	} else if upstreamYaml.GitRepoUrl != "" {
+	} else if upstreamYaml.GitRepo != "" {
 		chartSourceMetadata, err = fetchUpstreamGit(upstreamYaml)
 	} else {
 		err := errors.New("no valid repo options found")

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -319,9 +319,9 @@ func FetchUpstream(upstreamYaml upstreamyaml.UpstreamYaml) (ChartSourceMetadata,
 		return ChartSourceMetadata{}, err
 	}
 
-	if upstreamYaml.ChartYaml.Name != "" {
+	if upstreamYaml.ChartMetadata.Name != "" {
 		for _, version := range chartSourceMetadata.Versions {
-			version.Name = upstreamYaml.ChartYaml.Name
+			version.Name = upstreamYaml.ChartMetadata.Name
 		}
 	}
 

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -1,4 +1,4 @@
-package parse
+package upstreamyaml
 
 import (
 	"fmt"

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -17,7 +17,7 @@ const (
 
 type UpstreamYaml struct {
 	ArtifactHubPackage string         `json:"ArtifactHubPackage,omitempty"`
-	AHRepoName         string         `json:"ArtifactHubRepo,omitempty"`
+	ArtifactHubRepo    string         `json:"ArtifactHubRepo,omitempty"`
 	AutoInstall        string         `json:"AutoInstall,omitempty"`
 	ChartYaml          chart.Metadata `json:"ChartMetadata,omitempty"`
 	Deprecated         bool           `json:"Deprecated,omitempty"`

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -19,7 +19,7 @@ type UpstreamYaml struct {
 	ArtifactHubPackage string         `json:"ArtifactHubPackage,omitempty"`
 	ArtifactHubRepo    string         `json:"ArtifactHubRepo,omitempty"`
 	AutoInstall        string         `json:"AutoInstall,omitempty"`
-	ChartYaml          chart.Metadata `json:"ChartMetadata,omitempty"`
+	ChartMetadata      chart.Metadata `json:"ChartMetadata,omitempty"`
 	Deprecated         bool           `json:"Deprecated,omitempty"`
 	DisplayName        string         `json:"DisplayName,omitempty"`
 	Experimental       bool           `json:"Experimental,omitempty"`

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -39,7 +39,7 @@ type UpstreamYaml struct {
 	Vendor          string         `json:"Vendor,omitempty"`
 }
 
-func ParseUpstreamYaml(packagePath string) (UpstreamYaml, error) {
+func Parse(packagePath string) (UpstreamYaml, error) {
 	upstreamYamlPath := filepath.Join(packagePath, UpstreamOptionsFile)
 	logrus.Debugf("Attempting to parse %s", upstreamYamlPath)
 	upstreamYamlFile, err := os.ReadFile(upstreamYamlPath)

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -40,12 +40,14 @@ type UpstreamYaml struct {
 
 func Parse(upstreamYamlPath string) (*UpstreamYaml, error) {
 	logrus.Debugf("Attempting to parse %s", upstreamYamlPath)
-	upstreamYamlFile, err := os.ReadFile(upstreamYamlPath)
-	upstreamYaml := &UpstreamYaml{}
+	contents, err := os.ReadFile(upstreamYamlPath)
 	if err != nil {
-		logrus.Debug(err)
-	} else {
-		err = yaml.Unmarshal(upstreamYamlFile, &upstreamYaml)
+		return nil, fmt.Errorf("failed to read: %w", err)
+	}
+
+	upstreamYaml := &UpstreamYaml{}
+	if err := yaml.Unmarshal(contents, &upstreamYaml); err != nil {
+		return nil, fmt.Errorf("failed to parse as YAML: %w", err)
 	}
 
 	return upstreamYaml, err

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -29,7 +29,7 @@ type UpstreamYaml struct {
 	GitRepo            string         `json:"GitRepo,omitempty"`
 	GitSubdirectory    string         `json:"GitSubdirectory,omitempty"`
 	HelmChart          string         `json:"HelmChart,omitempty"`
-	HelmRepoUrl        string         `json:"HelmRepo,omitempty"`
+	HelmRepo           string         `json:"HelmRepo,omitempty"`
 	Hidden             bool           `json:"Hidden,omitempty"`
 	Namespace          string         `json:"Namespace,omitempty"`
 	PackageVersion     int            `json:"PackageVersion,omitempty"`

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -3,7 +3,6 @@ package upstreamyaml
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 
@@ -39,8 +38,7 @@ type UpstreamYaml struct {
 	Vendor          string         `json:"Vendor,omitempty"`
 }
 
-func Parse(packagePath string) (UpstreamYaml, error) {
-	upstreamYamlPath := filepath.Join(packagePath, UpstreamOptionsFile)
+func Parse(upstreamYamlPath string) (UpstreamYaml, error) {
 	logrus.Debugf("Attempting to parse %s", upstreamYamlPath)
 	upstreamYamlFile, err := os.ReadFile(upstreamYamlPath)
 	upstreamYaml := UpstreamYaml{}
@@ -53,8 +51,7 @@ func Parse(packagePath string) (UpstreamYaml, error) {
 	return upstreamYaml, err
 }
 
-func Write(packagePath string, upstreamYaml UpstreamYaml) error {
-	upstreamYamlPath := filepath.Join(packagePath, UpstreamOptionsFile)
+func Write(upstreamYamlPath string, upstreamYaml UpstreamYaml) error {
 	logrus.Debugf("Attempting to write %s", upstreamYamlPath)
 	contents, err := yaml.Marshal(upstreamYaml)
 	if err != nil {

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -53,7 +53,7 @@ func Parse(packagePath string) (UpstreamYaml, error) {
 	return upstreamYaml, err
 }
 
-func WriteUpstreamYaml(packagePath string, upstreamYaml UpstreamYaml) error {
+func Write(packagePath string, upstreamYaml UpstreamYaml) error {
 	upstreamYamlPath := filepath.Join(packagePath, UpstreamOptionsFile)
 	logrus.Debugf("Attempting to write %s", upstreamYamlPath)
 	contents, err := yaml.Marshal(upstreamYaml)

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -38,6 +38,16 @@ type UpstreamYaml struct {
 	Vendor          string         `json:"Vendor,omitempty"`
 }
 
+func (upstreamYaml *UpstreamYaml) setDefaults() {
+	if upstreamYaml.Fetch == "" {
+		upstreamYaml.Fetch = "latest"
+	}
+
+	if upstreamYaml.ReleaseName == "" {
+		upstreamYaml.ReleaseName = upstreamYaml.HelmChart
+	}
+}
+
 func Parse(upstreamYamlPath string) (*UpstreamYaml, error) {
 	logrus.Debugf("Attempting to parse %s", upstreamYamlPath)
 	contents, err := os.ReadFile(upstreamYamlPath)
@@ -49,6 +59,8 @@ func Parse(upstreamYamlPath string) (*UpstreamYaml, error) {
 	if err := yaml.Unmarshal(contents, &upstreamYaml); err != nil {
 		return nil, fmt.Errorf("failed to parse as YAML: %w", err)
 	}
+
+	upstreamYaml.setDefaults()
 
 	return upstreamYaml, err
 }

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -26,7 +26,7 @@ type UpstreamYaml struct {
 	Fetch              string         `json:"Fetch,omitempty"`
 	GitBranch          string         `json:"GitBranch,omitempty"`
 	GitHubRelease      bool           `json:"GitHubRelease,omitempty"`
-	GitRepoUrl         string         `json:"GitRepo,omitempty"`
+	GitRepo            string         `json:"GitRepo,omitempty"`
 	GitSubDirectory    string         `json:"GitSubdirectory,omitempty"`
 	HelmChart          string         `json:"HelmChart,omitempty"`
 	HelmRepoUrl        string         `json:"HelmRepo,omitempty"`

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -38,10 +38,10 @@ type UpstreamYaml struct {
 	Vendor          string         `json:"Vendor,omitempty"`
 }
 
-func Parse(upstreamYamlPath string) (UpstreamYaml, error) {
+func Parse(upstreamYamlPath string) (*UpstreamYaml, error) {
 	logrus.Debugf("Attempting to parse %s", upstreamYamlPath)
 	upstreamYamlFile, err := os.ReadFile(upstreamYamlPath)
-	upstreamYaml := UpstreamYaml{}
+	upstreamYaml := &UpstreamYaml{}
 	if err != nil {
 		logrus.Debug(err)
 	} else {

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -27,7 +27,7 @@ type UpstreamYaml struct {
 	GitBranch          string         `json:"GitBranch,omitempty"`
 	GitHubRelease      bool           `json:"GitHubRelease,omitempty"`
 	GitRepo            string         `json:"GitRepo,omitempty"`
-	GitSubDirectory    string         `json:"GitSubdirectory,omitempty"`
+	GitSubdirectory    string         `json:"GitSubdirectory,omitempty"`
 	HelmChart          string         `json:"HelmChart,omitempty"`
 	HelmRepoUrl        string         `json:"HelmRepo,omitempty"`
 	Hidden             bool           `json:"Hidden,omitempty"`

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -16,26 +16,26 @@ const (
 )
 
 type UpstreamYaml struct {
-	AHPackageName   string         `json:"ArtifactHubPackage,omitempty"`
-	AHRepoName      string         `json:"ArtifactHubRepo,omitempty"`
-	AutoInstall     string         `json:"AutoInstall,omitempty"`
-	ChartYaml       chart.Metadata `json:"ChartMetadata,omitempty"`
-	Deprecated      bool           `json:"Deprecated,omitempty"`
-	DisplayName     string         `json:"DisplayName,omitempty"`
-	Experimental    bool           `json:"Experimental,omitempty"`
-	Fetch           string         `json:"Fetch,omitempty"`
-	GitBranch       string         `json:"GitBranch,omitempty"`
-	GitHubRelease   bool           `json:"GitHubRelease,omitempty"`
-	GitRepoUrl      string         `json:"GitRepo,omitempty"`
-	GitSubDirectory string         `json:"GitSubdirectory,omitempty"`
-	HelmChart       string         `json:"HelmChart,omitempty"`
-	HelmRepoUrl     string         `json:"HelmRepo,omitempty"`
-	Hidden          bool           `json:"Hidden,omitempty"`
-	Namespace       string         `json:"Namespace,omitempty"`
-	PackageVersion  int            `json:"PackageVersion,omitempty"`
-	TrackVersions   []string       `json:"TrackVersions,omitempty"`
-	ReleaseName     string         `json:"ReleaseName,omitempty"`
-	Vendor          string         `json:"Vendor,omitempty"`
+	ArtifactHubPackage string         `json:"ArtifactHubPackage,omitempty"`
+	AHRepoName         string         `json:"ArtifactHubRepo,omitempty"`
+	AutoInstall        string         `json:"AutoInstall,omitempty"`
+	ChartYaml          chart.Metadata `json:"ChartMetadata,omitempty"`
+	Deprecated         bool           `json:"Deprecated,omitempty"`
+	DisplayName        string         `json:"DisplayName,omitempty"`
+	Experimental       bool           `json:"Experimental,omitempty"`
+	Fetch              string         `json:"Fetch,omitempty"`
+	GitBranch          string         `json:"GitBranch,omitempty"`
+	GitHubRelease      bool           `json:"GitHubRelease,omitempty"`
+	GitRepoUrl         string         `json:"GitRepo,omitempty"`
+	GitSubDirectory    string         `json:"GitSubdirectory,omitempty"`
+	HelmChart          string         `json:"HelmChart,omitempty"`
+	HelmRepoUrl        string         `json:"HelmRepo,omitempty"`
+	Hidden             bool           `json:"Hidden,omitempty"`
+	Namespace          string         `json:"Namespace,omitempty"`
+	PackageVersion     int            `json:"PackageVersion,omitempty"`
+	TrackVersions      []string       `json:"TrackVersions,omitempty"`
+	ReleaseName        string         `json:"ReleaseName,omitempty"`
+	Vendor             string         `json:"Vendor,omitempty"`
 }
 
 func (upstreamYaml *UpstreamYaml) setDefaults() {

--- a/pkg/upstreamyaml/upstreamyaml_test.go
+++ b/pkg/upstreamyaml/upstreamyaml_test.go
@@ -1,0 +1,46 @@
+package upstreamyaml
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMain(t *testing.T) {
+	t.Run("UpstreamYaml", func(t *testing.T) {
+		t.Run("setDefaults", func(t *testing.T) {
+			t.Run("should set Fetch field if not set", func(t *testing.T) {
+				upstreamYaml := &UpstreamYaml{}
+				upstreamYaml.setDefaults()
+				assert.Equal(t, "latest", upstreamYaml.Fetch)
+			})
+
+			t.Run("should not change Fetch field if set", func(t *testing.T) {
+				fetchValue := "newer"
+				upstreamYaml := &UpstreamYaml{
+					Fetch: fetchValue,
+				}
+				upstreamYaml.setDefaults()
+				assert.Equal(t, fetchValue, upstreamYaml.Fetch)
+			})
+
+			t.Run("should set ReleaseName field if not set", func(t *testing.T) {
+				helmChartValue := "helm-chart-value"
+				upstreamYaml := &UpstreamYaml{
+					HelmChart: helmChartValue,
+				}
+				upstreamYaml.setDefaults()
+				assert.Equal(t, helmChartValue, upstreamYaml.ReleaseName)
+			})
+
+			t.Run("should not change ReleaseName field if set", func(t *testing.T) {
+				releaseNameValue := "release-name-value"
+				upstreamYaml := &UpstreamYaml{
+					HelmChart:   "helm-chart-value",
+					ReleaseName: releaseNameValue,
+				}
+				upstreamYaml.setDefaults()
+				assert.Equal(t, releaseNameValue, upstreamYaml.ReleaseName)
+			})
+		})
+	})
+}

--- a/pkg/upstreamyaml/upstreamyaml_test.go
+++ b/pkg/upstreamyaml/upstreamyaml_test.go
@@ -42,5 +42,116 @@ func TestMain(t *testing.T) {
 				assert.Equal(t, releaseNameValue, upstreamYaml.ReleaseName)
 			})
 		})
+
+		t.Run("validate", func(t *testing.T) {
+			t.Run("if ArtifactHubPackage is set, ArtifactHubRepo must be set", func(t *testing.T) {
+				upstreamYaml := UpstreamYaml{
+					Fetch:              "latest",
+					ArtifactHubPackage: "test-package",
+				}
+				err := upstreamYaml.validate()
+				assert.ErrorContains(t, err, "ArtifactHubPackage is set but ArtifactHubRepo is not set")
+			})
+
+			t.Run("if ArtifactHubRepo is set, ArtifactHubPackage must be set", func(t *testing.T) {
+				upstreamYaml := UpstreamYaml{
+					Fetch:           "latest",
+					ArtifactHubRepo: "test-repo",
+				}
+				err := upstreamYaml.validate()
+				assert.ErrorContains(t, err, "ArtifactHubRepo is set but ArtifactHubPackage is not set")
+			})
+
+			t.Run("if Fetch is not latest, HelmChart must be set", func(t *testing.T) {
+				upstreamYaml := UpstreamYaml{
+					Fetch:    "notlatest",
+					HelmRepo: "https://example.com",
+				}
+				err := upstreamYaml.validate()
+				assert.ErrorContains(t, err, "Fetch is latest but HelmChart is not set")
+			})
+
+			t.Run("if Fetch is not latest, HelmRepo must be set", func(t *testing.T) {
+				upstreamYaml := UpstreamYaml{
+					Fetch:     "notlatest",
+					HelmChart: "test-chart",
+				}
+				err := upstreamYaml.validate()
+				assert.ErrorContains(t, err, "Fetch is latest but HelmRepo is not set")
+			})
+
+			t.Run("if GitBranch is set, GitRepo must be set", func(t *testing.T) {
+				upstreamYaml := UpstreamYaml{
+					Fetch:     "latest",
+					GitBranch: "test-branch",
+				}
+				err := upstreamYaml.validate()
+				assert.ErrorContains(t, err, "GitBranch is set but GitRepo is not set")
+			})
+
+			t.Run("if GitHubRelease is set, GitRepo must be set", func(t *testing.T) {
+				upstreamYaml := UpstreamYaml{
+					Fetch:         "latest",
+					GitHubRelease: true,
+				}
+				err := upstreamYaml.validate()
+				assert.ErrorContains(t, err, "GitHubRelease is set but GitRepo is not set")
+			})
+
+			t.Run("if GitSubdirectory is set, GitRepo must be set", func(t *testing.T) {
+				upstreamYaml := UpstreamYaml{
+					Fetch:           "latest",
+					GitSubdirectory: "test-subdirectory",
+				}
+				err := upstreamYaml.validate()
+				assert.ErrorContains(t, err, "GitSubdirectory is set but GitRepo is not set")
+			})
+
+			t.Run("if HelmChart is set, HelmRepo must be set", func(t *testing.T) {
+				upstreamYaml := UpstreamYaml{
+					Fetch:     "latest",
+					HelmChart: "test-chart",
+				}
+				err := upstreamYaml.validate()
+				assert.ErrorContains(t, err, "HelmChart is set but HelmRepo is not set")
+			})
+
+			t.Run("if HelmRepo is set, HelmChart must be set", func(t *testing.T) {
+				upstreamYaml := UpstreamYaml{
+					Fetch:    "latest",
+					HelmRepo: "test-repo",
+				}
+				err := upstreamYaml.validate()
+				assert.ErrorContains(t, err, "HelmRepo is set but HelmChart is not set")
+			})
+
+			t.Run("if TrackVersions is set, HelmChart must be set", func(t *testing.T) {
+				upstreamYaml := UpstreamYaml{
+					Fetch:         "latest",
+					TrackVersions: []string{"2.14"},
+					HelmRepo:      "https://example.com",
+				}
+				err := upstreamYaml.validate()
+				assert.ErrorContains(t, err, "TrackVersions is set but HelmChart is not set")
+			})
+
+			t.Run("if TrackVersions is set, HelmRepo must be set", func(t *testing.T) {
+				upstreamYaml := UpstreamYaml{
+					Fetch:         "latest",
+					TrackVersions: []string{"2.14"},
+					HelmChart:     "test-chart",
+				}
+				err := upstreamYaml.validate()
+				assert.ErrorContains(t, err, "TrackVersions is set but HelmRepo is not set")
+			})
+
+			t.Run("one of ArtifactHubPackage and ArtifactHubRepo, GitRepo, or HelmRepo and HelmChart must be present", func(t *testing.T) {
+				upstreamYaml := UpstreamYaml{
+					Fetch: "latest",
+				}
+				err := upstreamYaml.validate()
+				assert.ErrorContains(t, err, "must define upstream")
+			})
+		})
 	})
 }


### PR DESCRIPTION
In `partner-charts-ci` everything revolves around `upstream.yaml` files. Currently there is no validation for these files. Also, fields that have default values are not set to those default values at parse time. Instead, they are handled with `if` statements when the field is used. This PR adds `UpstreamYaml.setDefaults()` and `UpstreamYaml.validate()`, and calls them in `upstreamyaml.Parse()`. This improves the reliability and testability of the code.

This PR makes a few minor changes that do not impact functionality:
- Rename `pkg/parse` package to `pkg/upstreamyaml`.
- Rename `upstreamyaml.WriteUpstreamYaml` and `upstreamyaml.ParseUpstreamYaml` to `upstreamyaml.Write` and `upstreamyaml.Parse` respectively.
- Rename fields of `UpstreamYaml` to match what the user enters in `upstream.yaml` files.

There are a good number of commits here, but that is because I made many of them small. Each one has a particular goal that (I hope) is communicated by the commit message. Reviewing by commit will make the most sense here.