### PR TITLE
Remove `TrackVersions` from `UpstreamYaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ Options for `upstream.yaml`
 | Namespace | | Addes the 'namespace' annotation which hard-codes a deployment namespace for the chart
 | PackageVersion | | Used to generate new patch version of chart
 | ReleaseName | | Sets the value of the release-name Rancher annotation. Defaults to the chart name
-| TrackVersions | HelmChart, HelmRepo | Allows selection of multiple *Major.Minor* versions to track from upstream independently.
 | Vendor | | Sets the vendor name providing the chart
 
 ### Helm Repo
@@ -210,10 +209,6 @@ HelmChart: kubewarden-controller
 Vendor: SUSE
 DisplayName: Kubewarden Controller
 Fetch: newer
-TrackVersions:
-  - 0.4
-  - 1.0
-  - 1.1
 ChartMetadata:
   kubeVersion:  '>=1.21-0'
   icon: https://www.kubewarden.io/images/icon-kubewarden.svg

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -34,7 +34,6 @@ type UpstreamYaml struct {
 	Hidden             bool           `json:"Hidden,omitempty"`
 	Namespace          string         `json:"Namespace,omitempty"`
 	PackageVersion     int            `json:"PackageVersion,omitempty"`
-	TrackVersions      []string       `json:"TrackVersions,omitempty"`
 	ReleaseName        string         `json:"ReleaseName,omitempty"`
 	Vendor             string         `json:"Vendor,omitempty"`
 }
@@ -55,13 +54,6 @@ func (upstreamYaml *UpstreamYaml) validate() error {
 	}
 	if upstreamYaml.Fetch != "latest" && upstreamYaml.HelmRepo == "" {
 		return errors.New("Fetch is latest but HelmRepo is not set")
-	}
-
-	if len(upstreamYaml.TrackVersions) != 0 && upstreamYaml.HelmChart == "" {
-		return errors.New("TrackVersions is set but HelmChart is not set")
-	}
-	if len(upstreamYaml.TrackVersions) != 0 && upstreamYaml.HelmRepo == "" {
-		return errors.New("TrackVersions is set but HelmRepo is not set")
 	}
 
 	if upstreamYaml.ArtifactHubPackage != "" && upstreamYaml.ArtifactHubRepo == "" {

--- a/pkg/upstreamyaml/upstreamyaml_test.go
+++ b/pkg/upstreamyaml/upstreamyaml_test.go
@@ -125,26 +125,6 @@ func TestMain(t *testing.T) {
 				assert.ErrorContains(t, err, "HelmRepo is set but HelmChart is not set")
 			})
 
-			t.Run("if TrackVersions is set, HelmChart must be set", func(t *testing.T) {
-				upstreamYaml := UpstreamYaml{
-					Fetch:         "latest",
-					TrackVersions: []string{"2.14"},
-					HelmRepo:      "https://example.com",
-				}
-				err := upstreamYaml.validate()
-				assert.ErrorContains(t, err, "TrackVersions is set but HelmChart is not set")
-			})
-
-			t.Run("if TrackVersions is set, HelmRepo must be set", func(t *testing.T) {
-				upstreamYaml := UpstreamYaml{
-					Fetch:         "latest",
-					TrackVersions: []string{"2.14"},
-					HelmChart:     "test-chart",
-				}
-				err := upstreamYaml.validate()
-				assert.ErrorContains(t, err, "TrackVersions is set but HelmRepo is not set")
-			})
-
 			t.Run("one of ArtifactHubPackage and ArtifactHubRepo, GitRepo, or HelmRepo and HelmChart must be present", func(t *testing.T) {
 				upstreamYaml := UpstreamYaml{
 					Fetch: "latest",


### PR DESCRIPTION
The `TrackVersions` field requires too much maintenance. Accordingly, I am removing all references of it from this repository and from rancher/partner-charts.

The branch that is tied to this PR is made off of the branch from https://github.com/rancher/partner-charts-ci/pull/33. So, this PR is in draft mode until that one is merged, and this PR's branch is rebased onto `main-source`.