### PR TITLE
Validate that package names are the same across `index.yaml` and `packages/`

### DIFF
--- a/pkg/validate/matchnames.go
+++ b/pkg/validate/matchnames.go
@@ -1,0 +1,46 @@
+package validate
+
+import (
+	"fmt"
+
+	p "github.com/rancher/partner-charts-ci/pkg/paths"
+	"github.com/rancher/partner-charts-ci/pkg/pkg"
+
+	"helm.sh/helm/v3/pkg/repo"
+)
+
+func validateIndexYamlAndPackagesDirNamesMatch(paths p.Paths, _ ConfigurationYaml) []error {
+	indexYaml, err := repo.LoadIndexFile(paths.IndexYaml)
+	if err != nil {
+		return []error{fmt.Errorf("failed to read index.yaml: %s", err)}
+	}
+	packageWrappers, err := pkg.ListPackageWrappers(paths, "")
+	if err != nil {
+		return []error{fmt.Errorf("failed to list package wrappers: %w", err)}
+	}
+	return matchPackageNames(indexYaml, packageWrappers)
+}
+
+func matchPackageNames(indexYaml *repo.IndexFile, packageWrappers []pkg.PackageWrapper) []error {
+	errors := make([]error, 0, len(packageWrappers))
+	indexYamlNames := map[string]bool{}
+	for chartName, _ := range indexYaml.Entries {
+		indexYamlNames[chartName] = false
+	}
+	for _, packageWrapper := range packageWrappers {
+		if _, ok := indexYamlNames[packageWrapper.Name]; ok {
+			indexYamlNames[packageWrapper.Name] = true
+		} else {
+			error := fmt.Errorf("chart name %q is present in packages/ but not in index.yaml", packageWrapper.Name)
+			errors = append(errors, error)
+		}
+	}
+	for packageName, present := range indexYamlNames {
+		if !present {
+			error := fmt.Errorf("chart name %q is present in index.yaml but not in packages/", packageName)
+			errors = append(errors, error)
+		}
+	}
+
+	return errors
+}

--- a/pkg/validate/matchnames_test.go
+++ b/pkg/validate/matchnames_test.go
@@ -1,0 +1,91 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/rancher/partner-charts-ci/pkg/pkg"
+	"github.com/stretchr/testify/assert"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/repo"
+)
+
+// TODO: this function was copied from icons_test.go, which is added in another
+// PR. This can be deleted once the two branches are merged into main.
+func generateIndex(t *testing.T) *repo.IndexFile {
+	t.Helper()
+	return &repo.IndexFile{
+		Entries: map[string]repo.ChartVersions{
+			"chart1": repo.ChartVersions{
+				&repo.ChartVersion{
+					Metadata: &chart.Metadata{
+						Name:    "chart1",
+						Version: "1.0.0",
+						Icon:    "file://assets/icons/chart1.png",
+					},
+				},
+			},
+			"chart2": repo.ChartVersions{
+				&repo.ChartVersion{
+					Metadata: &chart.Metadata{
+						Name:    "chart2",
+						Version: "2.0.0",
+						Icon:    "file://assets/icons/chart2.png",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestMatchPackageNames(t *testing.T) {
+	t.Run("should produce no error when name is present in index.yaml but not in packages/", func(t *testing.T) {
+		indexYaml := generateIndex(t)
+		packageWrappers := []pkg.PackageWrapper{
+			{
+				Name:   "chart1",
+				Vendor: "vendor1",
+			},
+			{
+				Name:   "chart2",
+				Vendor: "vendor1",
+			},
+		}
+		errors := matchPackageNames(indexYaml, packageWrappers)
+		assert.Len(t, errors, 0)
+	})
+
+	t.Run("should produce error when name is present in index.yaml but not in packages/", func(t *testing.T) {
+		indexYaml := generateIndex(t)
+		packageWrappers := []pkg.PackageWrapper{
+			{
+				Name:   "chart1",
+				Vendor: "vendor1",
+			},
+		}
+		errors := matchPackageNames(indexYaml, packageWrappers)
+		assert.Len(t, errors, 1)
+		assert.ErrorContains(t, errors[0], `chart name "chart2" is present in index.yaml but not in packages/`)
+	})
+
+	t.Run("should produce error when name is present in packages/ but not in index.yaml", func(t *testing.T) {
+		indexYaml := generateIndex(t)
+		packageWrappers := []pkg.PackageWrapper{
+			{
+				Name:   "chart1",
+				Vendor: "vendor1",
+			},
+			{
+				Name:   "chart2",
+				Vendor: "vendor1",
+			},
+			{
+				Name:   "chart3",
+				Vendor: "vendor1",
+			},
+		}
+		errors := matchPackageNames(indexYaml, packageWrappers)
+		assert.Len(t, errors, 1)
+		assert.ErrorContains(t, errors[0], `chart name "chart3" is present in packages/ but not in index.yaml`)
+	})
+}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -15,6 +15,7 @@ func Run(paths p.Paths, configYaml ConfigurationYaml) []error {
 		preventReleasedChartModifications,
 		preventDuplicatePackageNames,
 		validatePackagesDirectory,
+		validateIndexYamlAndPackagesDirNamesMatch,
 	}
 	for _, validationFunc := range validationFuncs {
 		errors := validationFunc(paths, configYaml)


### PR DESCRIPTION
In order to make the repository easier to understand and work with (think: scripting) we want to ensure that package/chart names are always the same across `index.yaml` (and therefore `assets/` and `charts/`) and `packages/`. For example, we want the package at `packages/jfrog/artifactory-ha` to correspond to a helm chart with the name `artifactory-ha`. This PR introduces a validation that ensures that this is the case.