### PR TITLE
Introduce `paths.Paths` type to act as single source of truth for paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,8 +41,6 @@ const (
 	annotationReleaseName  = "catalog.cattle.io/release-name"
 	//packageEnvVariable sets the environment variable to check for a package name
 	packageEnvVariable = "PACKAGE"
-	//repositoryChartsDir sets the directory name for stored charts
-	repositoryChartsDir = "charts"
 	//repositoryPackagesDir sets the directory name for package configurations
 	repositoryPackagesDir = "packages"
 	featuredMax           = 5
@@ -120,7 +118,7 @@ func commitChanges(paths p.Paths, updatedList pkg.PackageList) error {
 
 	for _, packageWrapper := range updatedList {
 		assetsPath := filepath.Join(paths.Assets, packageWrapper.Vendor)
-		chartsPath := filepath.Join(repositoryChartsDir, packageWrapper.Vendor, packageWrapper.Name)
+		chartsPath := filepath.Join(paths.Charts, packageWrapper.Vendor, packageWrapper.Name)
 		packagesPath := filepath.Join(repositoryPackagesDir, packageWrapper.Vendor, packageWrapper.Name)
 
 		for _, path := range []string{assetsPath, chartsPath, packagesPath} {
@@ -997,7 +995,7 @@ func removePackage(c *cli.Context) error {
 
 	removalPaths := []string{
 		filepath.Join(p.GetRepoRoot(), repositoryPackagesDir, packageWrapper.Vendor, packageWrapper.Name),
-		filepath.Join(p.GetRepoRoot(), repositoryChartsDir, packageWrapper.Vendor, packageWrapper.Name),
+		filepath.Join(paths.Charts, packageWrapper.Vendor, packageWrapper.Name),
 	}
 
 	assetFiles, err := getExistingChartTgzFiles(paths, packageWrapper.Vendor, packageWrapper.Name)

--- a/main.go
+++ b/main.go
@@ -76,8 +76,8 @@ func NewChartWrapper(helmChart *chart.Chart) *ChartWrapper {
 	}
 }
 
-func annotate(vendor, chartName, annotation, value string, remove, onlyLatest bool) error {
-	existingCharts, err := loadExistingCharts(p.GetRepoRoot(), vendor, chartName)
+func annotate(paths p.Paths, vendor, chartName, annotation, value string, remove, onlyLatest bool) error {
+	existingCharts, err := loadExistingCharts(paths.RepoRoot, vendor, chartName)
 	if err != nil {
 		return fmt.Errorf("failed to load existing charts: %w", err)
 	}
@@ -97,7 +97,7 @@ func annotate(vendor, chartName, annotation, value string, remove, onlyLatest bo
 		}
 	}
 
-	if err := writeCharts(p.GetRepoRoot(), vendor, chartName, existingCharts); err != nil {
+	if err := writeCharts(paths.RepoRoot, vendor, chartName, existingCharts); err != nil {
 		return fmt.Errorf("failed to write charts: %w", err)
 	}
 
@@ -794,7 +794,8 @@ func addFeaturedChart(c *cli.Context) error {
 	} else {
 		vendor := packageWrapper.Vendor
 		chartName := packageWrapper.Name
-		if err := annotate(vendor, chartName, annotationFeatured, inputIndex, false, true); err != nil {
+		paths := p.Get()
+		if err := annotate(paths, vendor, chartName, annotationFeatured, inputIndex, false, true); err != nil {
 			return fmt.Errorf("failed to annotate %q: %w", packageWrapper.FullName(), err)
 		}
 		if err := writeIndex(); err != nil {
@@ -820,7 +821,8 @@ func removeFeaturedChart(c *cli.Context) error {
 
 	vendor := packageWrapper.Vendor
 	chartName := packageWrapper.Name
-	if err := annotate(vendor, chartName, annotationFeatured, "", true, false); err != nil {
+	paths := p.Get()
+	if err := annotate(paths, vendor, chartName, annotationFeatured, "", true, false); err != nil {
 		return fmt.Errorf("failed to deannotate %q: %w", packageWrapper.FullName(), err)
 	}
 
@@ -884,7 +886,8 @@ func hideChart(c *cli.Context) error {
 
 	vendor := packageWrapper.Vendor
 	chartName := packageWrapper.Name
-	if err := annotate(vendor, chartName, annotationHidden, "true", false, false); err != nil {
+	paths := p.Get()
+	if err := annotate(paths, vendor, chartName, annotationHidden, "true", false, false); err != nil {
 		return fmt.Errorf("failed to annotate package: %w", err)
 	}
 	if err := writeIndex(); err != nil {

--- a/main.go
+++ b/main.go
@@ -643,8 +643,9 @@ func writeIndex() error {
 //     path of the downloaded icon
 func ensureIcons(c *cli.Context) error {
 	currentPackage := os.Getenv(packageEnvVariable)
+	paths := p.Get()
 
-	packageWrappers, err := pkg.ListPackageWrappers(currentPackage)
+	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
 	}
@@ -678,7 +679,8 @@ func ensureIcons(c *cli.Context) error {
 // the changes will be applied on fetchUpstreams function
 func generateChanges(auto bool) {
 	currentPackage := os.Getenv(packageEnvVariable)
-	packageWrappers, err := pkg.ListPackageWrappers(currentPackage)
+	paths := p.Get()
+	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		logrus.Fatalf("failed to list packages: %s", err)
 	}
@@ -742,7 +744,10 @@ func generateChanges(auto bool) {
 
 // CLI function call - Prints list of available packages to STDout
 func listPackages(c *cli.Context) error {
-	packageList, err := pkg.ListPackageWrappers(os.Getenv(packageEnvVariable))
+	currentPackage := os.Getenv(packageEnvVariable)
+	paths := p.Get()
+
+	packageList, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
 	}
@@ -780,7 +785,8 @@ func addFeaturedChart(c *cli.Context) error {
 		return fmt.Errorf("featured number must be between %d and %d\n", 1, featuredMax)
 	}
 
-	packageList, err := pkg.ListPackageWrappers(featuredChart)
+	paths := p.Get()
+	packageList, err := pkg.ListPackageWrappers(paths, featuredChart)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
 	}
@@ -812,8 +818,9 @@ func removeFeaturedChart(c *cli.Context) error {
 		logrus.Fatal("Please provide the chart name as argument")
 	}
 	featuredChart := c.Args().Get(0)
+	paths := p.Get()
 
-	packageList, err := pkg.ListPackageWrappers(featuredChart)
+	packageList, err := pkg.ListPackageWrappers(paths, featuredChart)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
 	}
@@ -821,7 +828,6 @@ func removeFeaturedChart(c *cli.Context) error {
 
 	vendor := packageWrapper.Vendor
 	chartName := packageWrapper.Name
-	paths := p.Get()
 	if err := annotate(paths, vendor, chartName, annotationFeatured, "", true, false); err != nil {
 		return fmt.Errorf("failed to deannotate %q: %w", packageWrapper.FullName(), err)
 	}
@@ -870,8 +876,9 @@ func hideChart(c *cli.Context) error {
 		logrus.Fatal("Must provide exactly one package name as argument")
 	}
 	currentPackage := c.Args().Get(0)
+	paths := p.Get()
 
-	packageWrappers, err := pkg.ListPackageWrappers(currentPackage)
+	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
 	}
@@ -886,7 +893,6 @@ func hideChart(c *cli.Context) error {
 
 	vendor := packageWrapper.Vendor
 	chartName := packageWrapper.Name
-	paths := p.Get()
 	if err := annotate(paths, vendor, chartName, annotationHidden, "true", false, false); err != nil {
 		return fmt.Errorf("failed to annotate package: %w", err)
 	}
@@ -934,7 +940,8 @@ func validateRepo(c *cli.Context) error {
 // used to work on a single package.
 func cullCharts(c *cli.Context) error {
 	currentPackage := os.Getenv(packageEnvVariable)
-	packageWrappers, err := pkg.ListPackageWrappers(currentPackage)
+	paths := p.Get()
+	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
 	}
@@ -1029,8 +1036,9 @@ func removePackage(c *cli.Context) error {
 		return errors.New("must provide package name as argument")
 	}
 	currentPackage := c.Args().Get(0)
+	paths := p.Get()
 
-	packageWrappers, err := pkg.ListPackageWrappers(currentPackage)
+	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
 	}
@@ -1076,8 +1084,9 @@ func deprecatePackage(c *cli.Context) error {
 		return errors.New("must provide package name as argument")
 	}
 	currentPackage := c.Args().Get(0)
+	paths := p.Get()
 
-	packageWrappers, err := pkg.ListPackageWrappers(currentPackage)
+	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		return fmt.Errorf("failed to list package wrappers: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -103,10 +103,10 @@ func annotate(paths p.Paths, vendor, chartName, annotation, value string, remove
 }
 
 // Commits changes to index file, assets, charts, and packages
-func commitChanges(updatedList pkg.PackageList) error {
+func commitChanges(paths p.Paths, updatedList pkg.PackageList) error {
 	commitOptions := git.CommitOptions{}
 
-	r, err := git.PlainOpen(p.GetRepoRoot())
+	r, err := git.PlainOpen(paths.RepoRoot)
 	if err != nil {
 		return err
 	}
@@ -697,8 +697,7 @@ func generateChanges(auto bool) {
 	}
 
 	if auto {
-		err = commitChanges(packageList)
-		if err != nil {
+		if err := commitChanges(paths, packageList); err != nil {
 			logrus.Fatal(err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -41,8 +41,6 @@ const (
 	annotationReleaseName  = "catalog.cattle.io/release-name"
 	//packageEnvVariable sets the environment variable to check for a package name
 	packageEnvVariable = "PACKAGE"
-	//repositoryAssetsDir sets the directory name for chart asset files
-	repositoryAssetsDir = "assets"
 	//repositoryChartsDir sets the directory name for stored charts
 	repositoryChartsDir = "charts"
 	//repositoryPackagesDir sets the directory name for package configurations
@@ -121,7 +119,7 @@ func commitChanges(paths p.Paths, updatedList pkg.PackageList) error {
 	}
 
 	for _, packageWrapper := range updatedList {
-		assetsPath := filepath.Join(repositoryAssetsDir, packageWrapper.Vendor)
+		assetsPath := filepath.Join(paths.Assets, packageWrapper.Vendor)
 		chartsPath := filepath.Join(repositoryChartsDir, packageWrapper.Vendor, packageWrapper.Name)
 		packagesPath := filepath.Join(repositoryPackagesDir, packageWrapper.Vendor, packageWrapper.Name)
 
@@ -539,8 +537,7 @@ func getByAnnotation(paths p.Paths, annotation, value string) map[string]repo.Ch
 // index.yaml file should treat the charts' Chart.yaml files as the
 // authoritative source of chart metadata.
 func writeIndex(paths p.Paths) error {
-	assetsDirectoryPath := filepath.Join(p.GetRepoRoot(), repositoryAssetsDir)
-	newHelmIndexYaml, err := repo.IndexDirectory(assetsDirectoryPath, repositoryAssetsDir)
+	newHelmIndexYaml, err := repo.IndexDirectory(paths.Assets, filepath.Base(paths.Assets))
 	if err != nil {
 		return fmt.Errorf("failed to index assets directory: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -502,9 +502,8 @@ func ensureFeaturedAnnotation(existingCharts, newCharts []*ChartWrapper) error {
 // the specified annotation with the specified value. If value is "",
 // all repo.ChartVersions that have the specified annotation will be
 // returned, regardless of that annotation's value.
-func getByAnnotation(annotation, value string) map[string]repo.ChartVersions {
-	indexFilePath := filepath.Join(p.GetRepoRoot(), indexFile)
-	indexYaml, err := repo.LoadIndexFile(indexFilePath)
+func getByAnnotation(paths p.Paths, annotation, value string) map[string]repo.ChartVersions {
+	indexYaml, err := repo.LoadIndexFile(paths.IndexYaml)
 	if err != nil {
 		logrus.Fatalf("failed to read index.yaml: %s", err)
 	}
@@ -753,7 +752,7 @@ func addFeaturedChart(c *cli.Context) error {
 	}
 	packageWrapper := packageList[0]
 
-	featuredVersions := getByAnnotation(annotationFeatured, inputIndex)
+	featuredVersions := getByAnnotation(paths, annotationFeatured, inputIndex)
 	if len(featuredVersions) > 0 {
 		for chartName := range featuredVersions {
 			logrus.Errorf("%s already featured at index %d\n", chartName, featuredNumber)
@@ -803,7 +802,8 @@ func removeFeaturedChart(c *cli.Context) error {
 func listFeaturedCharts(c *cli.Context) {
 	indexConflict := false
 	featuredSorted := make([]string, featuredMax)
-	featuredVersions := getByAnnotation(annotationFeatured, "")
+	paths := p.Get()
+	featuredVersions := getByAnnotation(paths, annotationFeatured, "")
 
 	for chartName, chartVersion := range featuredVersions {
 		featuredIndex, err := strconv.Atoi(chartVersion[0].Annotations[annotationFeatured])

--- a/main.go
+++ b/main.go
@@ -179,10 +179,10 @@ func commitChanges(paths p.Paths, updatedList pkg.PackageList) error {
 	return nil
 }
 
-func ApplyUpdates(packageWrapper pkg.PackageWrapper) error {
+func ApplyUpdates(paths p.Paths, packageWrapper pkg.PackageWrapper) error {
 	logrus.Debugf("Applying updates for package %s/%s\n", packageWrapper.Vendor, packageWrapper.Name)
 
-	existingCharts, err := loadExistingCharts(p.GetRepoRoot(), packageWrapper.Vendor, packageWrapper.Name)
+	existingCharts, err := loadExistingCharts(paths.RepoRoot, packageWrapper.Vendor, packageWrapper.Name)
 	if err != nil {
 		return fmt.Errorf("failed to load existing charts: %w", err)
 	}
@@ -211,7 +211,7 @@ func ApplyUpdates(packageWrapper pkg.PackageWrapper) error {
 	allCharts := make([]*ChartWrapper, 0, len(existingCharts)+len(newCharts))
 	allCharts = append(allCharts, existingCharts...)
 	allCharts = append(allCharts, newCharts...)
-	if err := writeCharts(p.GetRepoRoot(), packageWrapper.Vendor, packageWrapper.Name, allCharts); err != nil {
+	if err := writeCharts(paths.RepoRoot, packageWrapper.Vendor, packageWrapper.Name, allCharts); err != nil {
 		return fmt.Errorf("failed to write charts: %w", err)
 	}
 
@@ -654,7 +654,7 @@ func generateChanges(auto bool) {
 		}
 
 		logrus.Debugf("Populating package from %s\n", packageWrapper.Path)
-		updated, err := packageWrapper.Populate()
+		updated, err := packageWrapper.Populate(paths)
 		if err != nil {
 			logrus.Errorf("failed to populate %s: %s", packageWrapper.FullName(), err)
 			continue
@@ -679,7 +679,7 @@ func generateChanges(auto bool) {
 
 	skippedList := make([]string, 0)
 	for _, packageWrapper := range packageList {
-		if err := ApplyUpdates(packageWrapper); err != nil {
+		if err := ApplyUpdates(paths, packageWrapper); err != nil {
 			logrus.Errorf("failed to apply updates for chart %q: %s", packageWrapper.Name, err)
 			skippedList = append(skippedList, packageWrapper.Name)
 		}

--- a/main.go
+++ b/main.go
@@ -39,8 +39,6 @@ const (
 	annotationKubeVersion  = "catalog.cattle.io/kube-version"
 	annotationNamespace    = "catalog.cattle.io/namespace"
 	annotationReleaseName  = "catalog.cattle.io/release-name"
-	//indexFile sets the filename for the repo index yaml
-	indexFile = "index.yaml"
 	//packageEnvVariable sets the environment variable to check for a package name
 	packageEnvVariable = "PACKAGE"
 	//repositoryAssetsDir sets the directory name for chart asset files
@@ -149,8 +147,8 @@ func commitChanges(paths p.Paths, updatedList pkg.PackageList) error {
 
 	}
 
-	if _, err := wt.Add(indexFile); err != nil {
-		return fmt.Errorf("failed to add %q to working tree: %w", indexFile, err)
+	if _, err := wt.Add(paths.IndexYaml); err != nil {
+		return fmt.Errorf("failed to add %q to working tree: %w", paths.IndexYaml, err)
 	}
 	commitMessage := "Added chart versions:\n"
 	sort.Sort(updatedList)
@@ -906,7 +904,7 @@ func cullCharts(c *cli.Context) error {
 	}
 	days := int(daysInt64)
 
-	_, newerChartVersions, err := getOlderAndNewerChartVersions(days)
+	_, newerChartVersions, err := getOlderAndNewerChartVersions(paths, days)
 	if err != nil {
 		return fmt.Errorf("failed to get older and newer chart versions: %w", err)
 	}
@@ -961,8 +959,8 @@ func cullCharts(c *cli.Context) error {
 // of chart name to slices of versions, one version per chartVersion.
 // The older versions are the first return value and the newer
 // versions are the second return value.
-func getOlderAndNewerChartVersions(days int) (map[string][]string, map[string][]string, error) {
-	indexYaml, err := repo.LoadIndexFile(indexFile)
+func getOlderAndNewerChartVersions(paths p.Paths, days int) (map[string][]string, map[string][]string, error) {
+	indexYaml, err := repo.LoadIndexFile(paths.IndexYaml)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read index file: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -600,7 +600,7 @@ func writeIndex(paths p.Paths) error {
 //     path of the downloaded icon
 func ensureIcons(c *cli.Context) error {
 	currentPackage := os.Getenv(packageEnvVariable)
-	paths := p.Get()
+	paths := p.GetPaths()
 
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
@@ -636,7 +636,7 @@ func ensureIcons(c *cli.Context) error {
 // the changes will be applied on fetchUpstreams function
 func generateChanges(auto bool) {
 	currentPackage := os.Getenv(packageEnvVariable)
-	paths := p.Get()
+	paths := p.GetPaths()
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		logrus.Fatalf("failed to list packages: %s", err)
@@ -701,7 +701,7 @@ func generateChanges(auto bool) {
 // listPackages prints out the packages in the current repository.
 func listPackages(c *cli.Context) error {
 	currentPackage := os.Getenv(packageEnvVariable)
-	paths := p.Get()
+	paths := p.GetPaths()
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
@@ -729,7 +729,7 @@ func addFeaturedChart(c *cli.Context) error {
 		return fmt.Errorf("featured number must be between %d and %d\n", 1, featuredMax)
 	}
 
-	paths := p.Get()
+	paths := p.GetPaths()
 	packageList, err := pkg.ListPackageWrappers(paths, featuredChart)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
@@ -744,7 +744,7 @@ func addFeaturedChart(c *cli.Context) error {
 	} else {
 		vendor := packageWrapper.Vendor
 		chartName := packageWrapper.Name
-		paths := p.Get()
+		paths := p.GetPaths()
 		if err := annotate(paths, vendor, chartName, annotationFeatured, inputIndex, false, true); err != nil {
 			return fmt.Errorf("failed to annotate %q: %w", packageWrapper.FullName(), err)
 		}
@@ -762,7 +762,7 @@ func removeFeaturedChart(c *cli.Context) error {
 		logrus.Fatal("Please provide the chart name as argument")
 	}
 	featuredChart := c.Args().Get(0)
-	paths := p.Get()
+	paths := p.GetPaths()
 
 	packageList, err := pkg.ListPackageWrappers(paths, featuredChart)
 	if err != nil {
@@ -786,7 +786,7 @@ func removeFeaturedChart(c *cli.Context) error {
 func listFeaturedCharts(c *cli.Context) {
 	indexConflict := false
 	featuredSorted := make([]string, featuredMax)
-	paths := p.Get()
+	paths := p.GetPaths()
 	featuredVersions := getByAnnotation(paths, annotationFeatured, "")
 
 	for chartName, chartVersion := range featuredVersions {
@@ -821,7 +821,7 @@ func hideChart(c *cli.Context) error {
 		logrus.Fatal("Must provide exactly one package name as argument")
 	}
 	currentPackage := c.Args().Get(0)
-	paths := p.Get()
+	paths := p.GetPaths()
 
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
@@ -862,7 +862,7 @@ func autoUpdate(c *cli.Context) {
 
 // CLI function call - Validates repo against released
 func validateRepo(c *cli.Context) error {
-	paths := p.Get()
+	paths := p.GetPaths()
 	configYaml, err := validate.ReadConfig(paths.ConfigurationYaml)
 	if err != nil {
 		logrus.Fatalf("failed to read configuration.yaml: %s\n", err)
@@ -878,7 +878,7 @@ func validateRepo(c *cli.Context) error {
 // used to work on a single package.
 func cullCharts(c *cli.Context) error {
 	currentPackage := os.Getenv(packageEnvVariable)
-	paths := p.Get()
+	paths := p.GetPaths()
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
@@ -974,7 +974,7 @@ func removePackage(c *cli.Context) error {
 		return errors.New("must provide package name as argument")
 	}
 	currentPackage := c.Args().Get(0)
-	paths := p.Get()
+	paths := p.GetPaths()
 
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
@@ -1022,7 +1022,7 @@ func deprecatePackage(c *cli.Context) error {
 		return errors.New("must provide package name as argument")
 	}
 	currentPackage := c.Args().Get(0)
-	paths := p.Get()
+	paths := p.GetPaths()
 
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -102,42 +102,6 @@ func annotate(paths p.Paths, vendor, chartName, annotation, value string, remove
 	return nil
 }
 
-func gitCleanup() error {
-	r, err := git.PlainOpen(p.GetRepoRoot())
-	if err != nil {
-		return err
-	}
-
-	wt, err := r.Worktree()
-	if err != nil {
-		return err
-	}
-
-	cleanOptions := git.CleanOptions{
-		Dir: true,
-	}
-
-	branch, err := r.Head()
-	if err != nil {
-		return err
-	}
-
-	logrus.Debugf("Branch: %s\n", branch.Name())
-	checkoutOptions := git.CheckoutOptions{
-		Branch: branch.Name(),
-		Force:  true,
-	}
-
-	err = wt.Clean(&cleanOptions)
-	if err != nil {
-		return err
-	}
-
-	err = wt.Checkout(&checkoutOptions)
-
-	return err
-}
-
 // Commits changes to index file, assets, charts, and packages
 func commitChanges(updatedList pkg.PackageList) error {
 	commitOptions := git.CommitOptions{}
@@ -908,13 +872,6 @@ func stageChanges(c *cli.Context) {
 	generateChanges(false)
 }
 
-func unstageChanges(c *cli.Context) {
-	err := gitCleanup()
-	if err != nil {
-		logrus.Error(err)
-	}
-}
-
 // CLI function call - Generates automated commit
 func autoUpdate(c *cli.Context) {
 	generateChanges(true)
@@ -1144,11 +1101,6 @@ func main() {
 			Name:   "stage",
 			Usage:  "Stage all changes. Does not commit",
 			Action: stageChanges,
-		},
-		{
-			Name:   "unstage",
-			Usage:  "Un-Stage all non-committed changes. Deletes all untracked files.",
-			Action: unstageChanges,
 		},
 		{
 			Name:   "hide",

--- a/main.go
+++ b/main.go
@@ -541,17 +541,16 @@ func getByAnnotation(paths p.Paths, annotation, value string) map[string]repo.Ch
 // but for the most part this function enforces the idea that the
 // index.yaml file should treat the charts' Chart.yaml files as the
 // authoritative source of chart metadata.
-func writeIndex() error {
-	indexFilePath := filepath.Join(p.GetRepoRoot(), indexFile)
+func writeIndex(paths p.Paths) error {
 	assetsDirectoryPath := filepath.Join(p.GetRepoRoot(), repositoryAssetsDir)
 	newHelmIndexYaml, err := repo.IndexDirectory(assetsDirectoryPath, repositoryAssetsDir)
 	if err != nil {
 		return fmt.Errorf("failed to index assets directory: %w", err)
 	}
 
-	oldHelmIndexYaml, err := repo.LoadIndexFile(indexFilePath)
+	oldHelmIndexYaml, err := repo.LoadIndexFile(paths.IndexYaml)
 	if errors.Is(err, os.ErrNotExist) {
-		if err := newHelmIndexYaml.WriteFile(indexFilePath, 0o644); err != nil {
+		if err := newHelmIndexYaml.WriteFile(paths.IndexYaml, 0o644); err != nil {
 			return fmt.Errorf("failed to write index.yaml: %w", err)
 		}
 		return nil
@@ -591,7 +590,7 @@ func writeIndex() error {
 
 	newHelmIndexYaml.SortEntries()
 
-	if err := newHelmIndexYaml.WriteFile(indexFilePath, 0o644); err != nil {
+	if err := newHelmIndexYaml.WriteFile(paths.IndexYaml, 0o644); err != nil {
 		return fmt.Errorf("failed to write index.yaml: %w", err)
 	}
 
@@ -627,7 +626,7 @@ func ensureIcons(c *cli.Context) error {
 		}
 	}
 
-	if err := writeIndex(); err != nil {
+	if err := writeIndex(paths); err != nil {
 		return fmt.Errorf("failed to write index: %w", err)
 	}
 
@@ -691,7 +690,7 @@ func generateChanges(auto bool) {
 		logrus.Fatalf("All packages skipped. Exiting...")
 	}
 
-	if err := writeIndex(); err != nil {
+	if err := writeIndex(paths); err != nil {
 		logrus.Error(err)
 	}
 
@@ -764,7 +763,7 @@ func addFeaturedChart(c *cli.Context) error {
 		if err := annotate(paths, vendor, chartName, annotationFeatured, inputIndex, false, true); err != nil {
 			return fmt.Errorf("failed to annotate %q: %w", packageWrapper.FullName(), err)
 		}
-		if err := writeIndex(); err != nil {
+		if err := writeIndex(paths); err != nil {
 			return fmt.Errorf("failed to write index: %w", err)
 		}
 	}
@@ -792,7 +791,7 @@ func removeFeaturedChart(c *cli.Context) error {
 		return fmt.Errorf("failed to deannotate %q: %w", packageWrapper.FullName(), err)
 	}
 
-	if err := writeIndex(); err != nil {
+	if err := writeIndex(paths); err != nil {
 		return fmt.Errorf("failed to write index: %w", err)
 	}
 
@@ -857,7 +856,7 @@ func hideChart(c *cli.Context) error {
 	if err := annotate(paths, vendor, chartName, annotationHidden, "true", false, false); err != nil {
 		return fmt.Errorf("failed to annotate package: %w", err)
 	}
-	if err := writeIndex(); err != nil {
+	if err := writeIndex(paths); err != nil {
 		return fmt.Errorf("failed to write index: %w", err)
 	}
 
@@ -950,7 +949,7 @@ func cullCharts(c *cli.Context) error {
 		logrus.Fatal("all packages skipped")
 	}
 
-	if err := writeIndex(); err != nil {
+	if err := writeIndex(paths); err != nil {
 		return fmt.Errorf("failed to write index: %w", err)
 	}
 
@@ -1026,7 +1025,7 @@ func removePackage(c *cli.Context) error {
 		}
 	}
 
-	if err := writeIndex(); err != nil {
+	if err := writeIndex(paths); err != nil {
 		return fmt.Errorf("failed to write index: %w", err)
 	}
 
@@ -1068,7 +1067,7 @@ func deprecatePackage(c *cli.Context) error {
 		return fmt.Errorf("failed to write charts: %w", err)
 	}
 
-	if err := writeIndex(); err != nil {
+	if err := writeIndex(paths); err != nil {
 		return fmt.Errorf("failed to write index: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -600,7 +600,10 @@ func writeIndex(paths p.Paths) error {
 //     path of the downloaded icon
 func ensureIcons(c *cli.Context) error {
 	currentPackage := os.Getenv(packageEnvVariable)
-	paths := p.GetPaths()
+	paths, err := p.GetPaths()
+	if err != nil {
+		return fmt.Errorf("failed to get paths: %w", err)
+	}
 
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
@@ -636,7 +639,10 @@ func ensureIcons(c *cli.Context) error {
 // the changes will be applied on fetchUpstreams function
 func generateChanges(auto bool) {
 	currentPackage := os.Getenv(packageEnvVariable)
-	paths := p.GetPaths()
+	paths, err := p.GetPaths()
+	if err != nil {
+		logrus.Fatalf("failed to get paths: %s", err)
+	}
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		logrus.Fatalf("failed to list packages: %s", err)
@@ -701,7 +707,10 @@ func generateChanges(auto bool) {
 // listPackages prints out the packages in the current repository.
 func listPackages(c *cli.Context) error {
 	currentPackage := os.Getenv(packageEnvVariable)
-	paths := p.GetPaths()
+	paths, err := p.GetPaths()
+	if err != nil {
+		return fmt.Errorf("failed to get paths: %w", err)
+	}
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
@@ -729,7 +738,10 @@ func addFeaturedChart(c *cli.Context) error {
 		return fmt.Errorf("featured number must be between %d and %d\n", 1, featuredMax)
 	}
 
-	paths := p.GetPaths()
+	paths, err := p.GetPaths()
+	if err != nil {
+		return fmt.Errorf("failed to get paths: %w", err)
+	}
 	packageList, err := pkg.ListPackageWrappers(paths, featuredChart)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
@@ -744,7 +756,10 @@ func addFeaturedChart(c *cli.Context) error {
 	} else {
 		vendor := packageWrapper.Vendor
 		chartName := packageWrapper.Name
-		paths := p.GetPaths()
+		paths, err := p.GetPaths()
+		if err != nil {
+			return fmt.Errorf("failed to get paths: %w", err)
+		}
 		if err := annotate(paths, vendor, chartName, annotationFeatured, inputIndex, false, true); err != nil {
 			return fmt.Errorf("failed to annotate %q: %w", packageWrapper.FullName(), err)
 		}
@@ -762,7 +777,10 @@ func removeFeaturedChart(c *cli.Context) error {
 		logrus.Fatal("Please provide the chart name as argument")
 	}
 	featuredChart := c.Args().Get(0)
-	paths := p.GetPaths()
+	paths, err := p.GetPaths()
+	if err != nil {
+		return fmt.Errorf("failed to get paths: %w", err)
+	}
 
 	packageList, err := pkg.ListPackageWrappers(paths, featuredChart)
 	if err != nil {
@@ -786,7 +804,10 @@ func removeFeaturedChart(c *cli.Context) error {
 func listFeaturedCharts(c *cli.Context) {
 	indexConflict := false
 	featuredSorted := make([]string, featuredMax)
-	paths := p.GetPaths()
+	paths, err := p.GetPaths()
+	if err != nil {
+		logrus.Fatalf("failed to get paths: %s", err)
+	}
 	featuredVersions := getByAnnotation(paths, annotationFeatured, "")
 
 	for chartName, chartVersion := range featuredVersions {
@@ -821,7 +842,10 @@ func hideChart(c *cli.Context) error {
 		logrus.Fatal("Must provide exactly one package name as argument")
 	}
 	currentPackage := c.Args().Get(0)
-	paths := p.GetPaths()
+	paths, err := p.GetPaths()
+	if err != nil {
+		return fmt.Errorf("failed to get paths: %w", err)
+	}
 
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
@@ -862,7 +886,10 @@ func autoUpdate(c *cli.Context) {
 
 // CLI function call - Validates repo against released
 func validateRepo(c *cli.Context) error {
-	paths := p.GetPaths()
+	paths, err := p.GetPaths()
+	if err != nil {
+		return fmt.Errorf("failed to get paths: %w", err)
+	}
 	configYaml, err := validate.ReadConfig(paths.ConfigurationYaml)
 	if err != nil {
 		logrus.Fatalf("failed to read configuration.yaml: %s\n", err)
@@ -878,7 +905,10 @@ func validateRepo(c *cli.Context) error {
 // used to work on a single package.
 func cullCharts(c *cli.Context) error {
 	currentPackage := os.Getenv(packageEnvVariable)
-	paths := p.GetPaths()
+	paths, err := p.GetPaths()
+	if err != nil {
+		return fmt.Errorf("failed to get paths: %w", err)
+	}
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
@@ -974,7 +1004,10 @@ func removePackage(c *cli.Context) error {
 		return errors.New("must provide package name as argument")
 	}
 	currentPackage := c.Args().Get(0)
-	paths := p.GetPaths()
+	paths, err := p.GetPaths()
+	if err != nil {
+		return fmt.Errorf("failed to get paths: %w", err)
+	}
 
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {
@@ -1022,7 +1055,10 @@ func deprecatePackage(c *cli.Context) error {
 		return errors.New("must provide package name as argument")
 	}
 	currentPackage := c.Args().Get(0)
-	paths := p.GetPaths()
+	paths, err := p.GetPaths()
+	if err != nil {
+		return fmt.Errorf("failed to get paths: %w", err)
+	}
 
 	packageWrappers, err := pkg.ListPackageWrappers(paths, currentPackage)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -40,10 +40,8 @@ const (
 	annotationReleaseName  = "catalog.cattle.io/release-name"
 	//packageEnvVariable sets the environment variable to check for a package name
 	packageEnvVariable = "PACKAGE"
-	//repositoryPackagesDir sets the directory name for package configurations
-	repositoryPackagesDir = "packages"
-	featuredMax           = 5
-	upstreamYamlFile      = "upstream.yaml"
+	featuredMax        = 5
+	upstreamYamlFile   = "upstream.yaml"
 )
 
 var (
@@ -126,7 +124,7 @@ func commitChanges(paths p.Paths, updatedPackageWrappers []pkg.PackageWrapper) e
 	for _, packageWrapper := range updatedPackageWrappers {
 		assetsPath := filepath.Join(paths.Assets, packageWrapper.Vendor)
 		chartsPath := filepath.Join(paths.Charts, packageWrapper.Vendor, packageWrapper.Name)
-		packagesPath := filepath.Join(repositoryPackagesDir, packageWrapper.Vendor, packageWrapper.Name)
+		packagesPath := filepath.Join(paths.Packages, packageWrapper.Vendor, packageWrapper.Name)
 
 		for _, path := range []string{assetsPath, chartsPath, packagesPath} {
 			if _, err := wt.Add(path); err != nil {
@@ -989,7 +987,7 @@ func removePackage(c *cli.Context) error {
 	}
 
 	removalPaths := []string{
-		filepath.Join(p.GetRepoRoot(), repositoryPackagesDir, packageWrapper.Vendor, packageWrapper.Name),
+		filepath.Join(paths.Packages, packageWrapper.Vendor, packageWrapper.Name),
 		filepath.Join(paths.Charts, packageWrapper.Vendor, packageWrapper.Name),
 	}
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -50,7 +49,6 @@ const (
 	repositoryChartsDir = "charts"
 	//repositoryPackagesDir sets the directory name for package configurations
 	repositoryPackagesDir = "packages"
-	configOptionsFile     = "configuration.yaml"
 	featuredMax           = 5
 	upstreamYamlFile      = "upstream.yaml"
 )
@@ -924,13 +922,13 @@ func autoUpdate(c *cli.Context) {
 
 // CLI function call - Validates repo against released
 func validateRepo(c *cli.Context) error {
-	configYamlPath := path.Join(p.GetRepoRoot(), configOptionsFile)
-	configYaml, err := validate.ReadConfig(configYamlPath)
+	paths := p.Get()
+	configYaml, err := validate.ReadConfig(paths.ConfigurationYaml)
 	if err != nil {
-		logrus.Fatalf("failed to read %s: %s\n", configOptionsFile, err)
+		logrus.Fatalf("failed to read configuration.yaml: %s\n", err)
 	}
 
-	validationErrors := validate.Run(configYaml)
+	validationErrors := validate.Run(paths, configYaml)
 
 	return errors.Join(validationErrors...)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -4,12 +4,27 @@ import (
 	"path/filepath"
 	"testing"
 
+	p "github.com/rancher/partner-charts-ci/pkg/paths"
 	"github.com/rancher/partner-charts-ci/pkg/pkg"
 	"github.com/rancher/partner-charts-ci/pkg/upstreamyaml"
 	"github.com/stretchr/testify/assert"
 
 	"helm.sh/helm/v3/pkg/chart"
 )
+
+func getPaths(t *testing.T, repoRoot string) p.Paths {
+	t.Helper()
+	assets := filepath.Join(repoRoot, "assets")
+	return p.Paths{
+		RepoRoot:          repoRoot,
+		Assets:            assets,
+		Charts:            filepath.Join(repoRoot, "charts"),
+		ConfigurationYaml: filepath.Join(repoRoot, "configuration.yaml"),
+		Icons:             filepath.Join(assets, "icons"),
+		IndexYaml:         filepath.Join(repoRoot, "index.yaml"),
+		Packages:          filepath.Join(repoRoot, "packages"),
+	}
+}
 
 func TestMain(t *testing.T) {
 	t.Run("applyOverlayFiles", func(t *testing.T) {
@@ -453,11 +468,11 @@ func TestMain(t *testing.T) {
 					},
 				},
 			}
-			repoRoot := t.TempDir()
-			if err := writeCharts(repoRoot, vendor, chartName, newCharts); err != nil {
+			paths := getPaths(t, t.TempDir())
+			if err := writeCharts(paths, vendor, chartName, newCharts); err != nil {
 				t.Fatalf("unexpected error in writeCharts: %s", err)
 			}
-			chartsFromDisk, err := loadExistingCharts(repoRoot, vendor, chartName)
+			chartsFromDisk, err := loadExistingCharts(paths.RepoRoot, vendor, chartName)
 			if err != nil {
 				t.Fatalf("unexpected error in loadExistingCharts: %s", err)
 			}
@@ -499,14 +514,14 @@ func TestMain(t *testing.T) {
 					},
 				},
 			}
-			repoRoot := t.TempDir()
-			if err := writeCharts(repoRoot, vendor, chartName, newCharts); err != nil {
+			paths := getPaths(t, t.TempDir())
+			if err := writeCharts(paths, vendor, chartName, newCharts); err != nil {
 				t.Fatalf("unexpected error in first writeCharts call: %s", err)
 			}
-			if err := writeCharts(repoRoot, vendor, chartName, newCharts[0:2]); err != nil {
+			if err := writeCharts(paths, vendor, chartName, newCharts[0:2]); err != nil {
 				t.Fatalf("unexpected error in second writeCharts call: %s", err)
 			}
-			chartsFromDisk, err := loadExistingCharts(repoRoot, vendor, chartName)
+			chartsFromDisk, err := loadExistingCharts(paths.RepoRoot, vendor, chartName)
 			if err != nil {
 				t.Fatalf("unexpected error in loadExistingCharts: %s", err)
 			}
@@ -541,11 +556,11 @@ func TestMain(t *testing.T) {
 					},
 				},
 			}
-			repoRoot := t.TempDir()
-			if err := writeCharts(repoRoot, vendor, chartName, newCharts); err != nil {
+			paths := getPaths(t, t.TempDir())
+			if err := writeCharts(paths, vendor, chartName, newCharts); err != nil {
 				t.Fatalf("unexpected error in first call of writeCharts: %s", err)
 			}
-			chartsFromDisk, err := loadExistingCharts(repoRoot, vendor, chartName)
+			chartsFromDisk, err := loadExistingCharts(paths.RepoRoot, vendor, chartName)
 			if err != nil {
 				t.Fatalf("unexpected error in first call of loadExistingCharts: %s", err)
 			}
@@ -558,10 +573,10 @@ func TestMain(t *testing.T) {
 			}
 			chartsFromDisk[0].Modified = true
 
-			if err := writeCharts(repoRoot, vendor, chartName, chartsFromDisk); err != nil {
+			if err := writeCharts(paths, vendor, chartName, chartsFromDisk); err != nil {
 				t.Fatalf("unexpected error in second call of writeCharts: %s", err)
 			}
-			newChartsFromDisk, err := loadExistingCharts(repoRoot, vendor, chartName)
+			newChartsFromDisk, err := loadExistingCharts(paths.RepoRoot, vendor, chartName)
 			if err != nil {
 				t.Fatalf("unexpected error in second call of loadExistingCharts: %s", err)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -425,7 +425,8 @@ func TestMain(t *testing.T) {
 			vendor := "f5"
 			packageName := "nginx-ingress"
 			repoRoot := filepath.Join("testdata", "loadExistingCharts")
-			chartWrappers, err := loadExistingCharts(repoRoot, vendor, packageName)
+			paths := getPaths(t, repoRoot)
+			chartWrappers, err := loadExistingCharts(paths, vendor, packageName)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}
@@ -472,7 +473,7 @@ func TestMain(t *testing.T) {
 			if err := writeCharts(paths, vendor, chartName, newCharts); err != nil {
 				t.Fatalf("unexpected error in writeCharts: %s", err)
 			}
-			chartsFromDisk, err := loadExistingCharts(paths.RepoRoot, vendor, chartName)
+			chartsFromDisk, err := loadExistingCharts(paths, vendor, chartName)
 			if err != nil {
 				t.Fatalf("unexpected error in loadExistingCharts: %s", err)
 			}
@@ -521,7 +522,7 @@ func TestMain(t *testing.T) {
 			if err := writeCharts(paths, vendor, chartName, newCharts[0:2]); err != nil {
 				t.Fatalf("unexpected error in second writeCharts call: %s", err)
 			}
-			chartsFromDisk, err := loadExistingCharts(paths.RepoRoot, vendor, chartName)
+			chartsFromDisk, err := loadExistingCharts(paths, vendor, chartName)
 			if err != nil {
 				t.Fatalf("unexpected error in loadExistingCharts: %s", err)
 			}
@@ -560,7 +561,7 @@ func TestMain(t *testing.T) {
 			if err := writeCharts(paths, vendor, chartName, newCharts); err != nil {
 				t.Fatalf("unexpected error in first call of writeCharts: %s", err)
 			}
-			chartsFromDisk, err := loadExistingCharts(paths.RepoRoot, vendor, chartName)
+			chartsFromDisk, err := loadExistingCharts(paths, vendor, chartName)
 			if err != nil {
 				t.Fatalf("unexpected error in first call of loadExistingCharts: %s", err)
 			}
@@ -576,7 +577,7 @@ func TestMain(t *testing.T) {
 			if err := writeCharts(paths, vendor, chartName, chartsFromDisk); err != nil {
 				t.Fatalf("unexpected error in second call of writeCharts: %s", err)
 			}
-			newChartsFromDisk, err := loadExistingCharts(paths.RepoRoot, vendor, chartName)
+			newChartsFromDisk, err := loadExistingCharts(paths, vendor, chartName)
 			if err != nil {
 				t.Fatalf("unexpected error in second call of loadExistingCharts: %s", err)
 			}

--- a/pkg/icons/icons.go
+++ b/pkg/icons/icons.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	p "github.com/rancher/partner-charts-ci/pkg/paths"
 	"github.com/sirupsen/logrus"
 )
 
@@ -30,7 +31,7 @@ func GetDownloadedIconPath(packageName string) (string, error) {
 // EnsureIconDownloaded downloads the icon at iconUrl to the icon file path
 // for package packageName. If a file already exists at this path, the
 // download is skipped. Returns the path to the icon.
-func EnsureIconDownloaded(iconUrl, packageName string) (string, error) {
+func EnsureIconDownloaded(paths p.Paths, iconUrl, packageName string) (string, error) {
 	if localIconPath, err := GetDownloadedIconPath(packageName); err == nil {
 		return localIconPath, nil
 	}
@@ -57,7 +58,7 @@ func EnsureIconDownloaded(iconUrl, packageName string) (string, error) {
 		}
 	}
 
-	localIconPath := filepath.Join("assets", "icons", packageName+ext)
+	localIconPath := filepath.Join(paths.Icons, packageName+ext)
 	if err := os.WriteFile(localIconPath, contents, 0o644); err != nil {
 		return "", fmt.Errorf("failed to write response to file: %w", err)
 	}

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -22,7 +22,7 @@ type Paths struct {
 	RepoRoot          string
 }
 
-func Get() Paths {
+func GetPaths() Paths {
 	if paths == nil {
 		// TODO: once GetRepoRoot is no longer used, remove this call and inline
 		// necessary parts of the code. We call it here in order to make sure

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -44,6 +44,8 @@ func Get() Paths {
 
 // GetRepoRoot fetches absolute repository root path. If the working directory
 // is not the root of a git repo, exits the program with an error.
+// TODO: remove this function. Only paths.Get() should be used to get access
+// to paths data.
 func GetRepoRoot() string {
 	repoRoot, err := os.Getwd()
 	if err != nil {

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -8,9 +8,42 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// GetRepoRoot fetches absolute repository root path. If the
-// working directory is not the root of a git repo, exits the
-// program with an error.
+var paths *Paths
+
+// Paths is a type that contains all of the paths that are relevant
+// to this tool. This approach facilitates unit testing.
+type Paths struct {
+	Assets            string
+	Charts            string
+	ConfigurationYaml string
+	Icons             string
+	IndexYaml         string
+	Packages          string
+	RepoRoot          string
+}
+
+func Get() Paths {
+	if paths == nil {
+		// TODO: once GetRepoRoot is no longer used, remove this call and inline
+		// necessary parts of the code. We call it here in order to make sure
+		// we are at the repository root.
+		repoRoot := GetRepoRoot()
+		assets := "assets"
+		paths = &Paths{
+			Assets:            assets,
+			Charts:            "charts",
+			ConfigurationYaml: "configuration.yaml",
+			Icons:             filepath.Join(assets, "icons"),
+			IndexYaml:         "index.yaml",
+			Packages:          "packages",
+			RepoRoot:          repoRoot,
+		}
+	}
+	return *paths
+}
+
+// GetRepoRoot fetches absolute repository root path. If the working directory
+// is not the root of a git repo, exits the program with an error.
 func GetRepoRoot() string {
 	repoRoot, err := os.Getwd()
 	if err != nil {

--- a/pkg/pkg/wrapper.go
+++ b/pkg/pkg/wrapper.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/partner-charts-ci/pkg/conform"
 	"github.com/rancher/partner-charts-ci/pkg/fetcher"
-	"github.com/rancher/partner-charts-ci/pkg/paths"
+	p "github.com/rancher/partner-charts-ci/pkg/paths"
 	"github.com/rancher/partner-charts-ci/pkg/upstreamyaml"
 	"github.com/sirupsen/logrus"
 
@@ -285,7 +285,7 @@ func collectNonStoredVersions(versions repo.ChartVersions, storedVersions repo.C
 
 func getStoredVersions(chartName string) (repo.ChartVersions, error) {
 	storedVersions := repo.ChartVersions{}
-	indexFilePath := filepath.Join(paths.GetRepoRoot(), "index.yaml")
+	indexFilePath := filepath.Join(p.GetRepoRoot(), "index.yaml")
 	helmIndexYaml, err := repo.LoadIndexFile(indexFilePath)
 	if err != nil {
 		return storedVersions, fmt.Errorf("failed to load index file: %w", err)

--- a/pkg/pkg/wrapper.go
+++ b/pkg/pkg/wrapper.go
@@ -45,27 +45,6 @@ type PackageWrapper struct {
 	Vendor string
 }
 
-type PackageList []PackageWrapper
-
-func (p PackageList) Len() int {
-	return len(p)
-}
-
-func (p PackageList) Swap(i, j int) {
-	p[i], p[j] = p[j], p[i]
-}
-
-func (p PackageList) Less(i, j int) bool {
-	if p[i].SourceMetadata != nil && p[j].SourceMetadata != nil {
-		if p[i].Vendor != p[j].Vendor {
-			return p[i].Vendor < p[j].Vendor
-		}
-		return p[i].Name < p[j].Name
-	}
-
-	return false
-}
-
 func (packageWrapper *PackageWrapper) FullName() string {
 	return packageWrapper.Vendor + "/" + packageWrapper.Name
 }
@@ -137,7 +116,7 @@ func (pw PackageWrapper) GetOverlayFiles() (map[string][]byte, error) {
 // it must be in <vendor>/<name> format (i.e. the "full" package name).
 // If currentPackage is specified, the function returns a slice with only
 // one element, which is the specified package.
-func ListPackageWrappers(paths p.Paths, currentPackage string) (PackageList, error) {
+func ListPackageWrappers(paths p.Paths, currentPackage string) ([]PackageWrapper, error) {
 	var globPattern string
 	if currentPackage == "" {
 		globPattern = paths.Packages + "/*/*"
@@ -156,7 +135,7 @@ func ListPackageWrappers(paths p.Paths, currentPackage string) (PackageList, err
 		}
 	}
 
-	packageList := make(PackageList, 0, len(matches))
+	packageList := make([]PackageWrapper, 0, len(matches))
 	for _, match := range matches {
 		parts := strings.Split(match, "/")
 		if len(parts) != 3 {

--- a/pkg/pkg/wrapper.go
+++ b/pkg/pkg/wrapper.go
@@ -140,9 +140,9 @@ func (pw PackageWrapper) GetOverlayFiles() (map[string][]byte, error) {
 func ListPackageWrappers(paths p.Paths, currentPackage string) (PackageList, error) {
 	var globPattern string
 	if currentPackage == "" {
-		globPattern = "packages/*/*"
+		globPattern = paths.Packages + "/*/*"
 	} else {
-		globPattern = filepath.Join("packages", currentPackage)
+		globPattern = filepath.Join(paths.Packages, currentPackage)
 	}
 	matches, err := filepath.Glob(globPattern)
 	if err != nil {

--- a/pkg/pkg/wrapper.go
+++ b/pkg/pkg/wrapper.go
@@ -136,7 +136,7 @@ func (pw PackageWrapper) GetOverlayFiles() (map[string][]byte, error) {
 // it must be in <vendor>/<name> format (i.e. the "full" package name).
 // If currentPackage is specified, the function returns a slice with only
 // one element, which is the specified package.
-func ListPackageWrappers(currentPackage string) (PackageList, error) {
+func ListPackageWrappers(paths p.Paths, currentPackage string) (PackageList, error) {
 	var globPattern string
 	if currentPackage == "" {
 		globPattern = "packages/*/*"

--- a/pkg/validate/duplicatenames.go
+++ b/pkg/validate/duplicatenames.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"fmt"
 
+	p "github.com/rancher/partner-charts-ci/pkg/paths"
 	"github.com/rancher/partner-charts-ci/pkg/pkg"
 )
 
@@ -11,7 +12,9 @@ import (
 // charts' names come from the package names. So, we need to ensure that users
 // cannot create a package with a name that another package already has.
 func preventDuplicatePackageNames(_ ConfigurationYaml) []error {
-	packageWrappers, err := pkg.ListPackageWrappers("")
+	// TODO: remove this once we can pass paths down from the top level
+	paths := p.Get()
+	packageWrappers, err := pkg.ListPackageWrappers(paths, "")
 	if err != nil {
 		return []error{fmt.Errorf("failed to list package wrappers: %w", err)}
 	}

--- a/pkg/validate/duplicatenames.go
+++ b/pkg/validate/duplicatenames.go
@@ -19,7 +19,7 @@ func preventDuplicatePackageNames(paths p.Paths, _ ConfigurationYaml) []error {
 	return findDuplicateNames(packageWrappers)
 }
 
-func findDuplicateNames(packageWrappers pkg.PackageList) []error {
+func findDuplicateNames(packageWrappers []pkg.PackageWrapper) []error {
 	errors := make([]error, 0, len(packageWrappers))
 	packageNames := make(map[string]string)
 	for _, packageWrapper := range packageWrappers {

--- a/pkg/validate/duplicatenames.go
+++ b/pkg/validate/duplicatenames.go
@@ -11,9 +11,7 @@ import (
 // that are eventually served from the partner charts repository are not. The
 // charts' names come from the package names. So, we need to ensure that users
 // cannot create a package with a name that another package already has.
-func preventDuplicatePackageNames(_ ConfigurationYaml) []error {
-	// TODO: remove this once we can pass paths down from the top level
-	paths := p.Get()
+func preventDuplicatePackageNames(paths p.Paths, _ ConfigurationYaml) []error {
 	packageWrappers, err := pkg.ListPackageWrappers(paths, "")
 	if err != nil {
 		return []error{fmt.Errorf("failed to list package wrappers: %w", err)}

--- a/pkg/validate/duplicatenames_test.go
+++ b/pkg/validate/duplicatenames_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestPreventDuplicatePackageNames(t *testing.T) {
 	t.Run("should return no errors when no duplicates are present", func(t *testing.T) {
-		packageWrappers := pkg.PackageList{
+		packageWrappers := []pkg.PackageWrapper{
 			{
 				Name:   "package1",
 				Vendor: "vendor1",
@@ -24,7 +24,7 @@ func TestPreventDuplicatePackageNames(t *testing.T) {
 	})
 
 	t.Run("should return correct number of errors when duplicates are present", func(t *testing.T) {
-		packageWrappers := pkg.PackageList{
+		packageWrappers := []pkg.PackageWrapper{
 			{
 				Name:   "package1",
 				Vendor: "vendor1",

--- a/pkg/validate/modification.go
+++ b/pkg/validate/modification.go
@@ -39,7 +39,7 @@ func (directoryComparison *DirectoryComparison) Merge(newComparison DirectoryCom
 // versions have been modified outside of a few that must be allowed,
 // such as the deprecated field of Chart.yaml and Rancher-specific
 // annotations.
-func preventReleasedChartModifications(configYaml ConfigurationYaml) []error {
+func preventReleasedChartModifications(paths p.Paths, configYaml ConfigurationYaml) []error {
 	cloneDir, err := os.MkdirTemp("", "gitRepo")
 	if err != nil {
 		logrus.Fatal(err)
@@ -54,7 +54,9 @@ func preventReleasedChartModifications(configYaml ConfigurationYaml) []error {
 	directoryComparison := DirectoryComparison{}
 	for _, dirPath := range []string{"assets"} {
 		upstreamPath := path.Join(cloneDir, dirPath)
-		updatePath := path.Join(p.GetRepoRoot(), dirPath)
+		// TODO: leaving this (almost) as-is because this was changed in #35.
+		// Use paths.Assets instead of paths.RepoRoot once that PR is merged.
+		updatePath := path.Join(paths.RepoRoot, dirPath)
 		if _, err := os.Stat(updatePath); os.IsNotExist(err) {
 			logrus.Infof("Directory '%s' not in source. Skipping...", dirPath)
 			continue

--- a/pkg/validate/modification.go
+++ b/pkg/validate/modification.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/rancher/partner-charts-ci/pkg/conform"
-	"github.com/rancher/partner-charts-ci/pkg/paths"
+	p "github.com/rancher/partner-charts-ci/pkg/paths"
 	"github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/chart/loader"
 )
@@ -54,7 +54,7 @@ func preventReleasedChartModifications(configYaml ConfigurationYaml) []error {
 	directoryComparison := DirectoryComparison{}
 	for _, dirPath := range []string{"assets"} {
 		upstreamPath := path.Join(cloneDir, dirPath)
-		updatePath := path.Join(paths.GetRepoRoot(), dirPath)
+		updatePath := path.Join(p.GetRepoRoot(), dirPath)
 		if _, err := os.Stat(updatePath); os.IsNotExist(err) {
 			logrus.Infof("Directory '%s' not in source. Skipping...", dirPath)
 			continue

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -1,18 +1,22 @@
 package validate
 
+import (
+	p "github.com/rancher/partner-charts-ci/pkg/paths"
+)
+
 // A ValidationFunc is a function that checks one specific thing about the
 // partner charts repository. If anything is wrong, it may return one or
 // more errors explaining what is wrong.
-type ValidationFunc func(configYaml ConfigurationYaml) []error
+type ValidationFunc func(paths p.Paths, configYaml ConfigurationYaml) []error
 
-func Run(configYaml ConfigurationYaml) []error {
+func Run(paths p.Paths, configYaml ConfigurationYaml) []error {
 	validationErrors := []error{}
 	validationFuncs := []ValidationFunc{
 		preventReleasedChartModifications,
 		preventDuplicatePackageNames,
 	}
 	for _, validationFunc := range validationFuncs {
-		errors := validationFunc(configYaml)
+		errors := validationFunc(paths, configYaml)
 		validationErrors = append(validationErrors, errors...)
 	}
 	return validationErrors


### PR DESCRIPTION
The benefit of this approach is that we can pass a special version of `paths.Paths` into functions when doing unit/integration tests. This makes tests possible where they previously would not have been.

While making these changes, I also noticed the `unstage` command. This operation is better done by commands such as `git reset --hard HEAD`, `git restore .`, `git clean -ffdx .` and other such commands. Accordingly I am removing it.

Don't be intimidated by the number of commits here - this PR is simply going through the code and replacing any uses of `paths.GetRepoRoot()` and hard references to paths (i.e. `"assets"`) with `paths.Paths`.