### PR TITLE
Remove `stage` subcommand and rename `auto` subcommand

### DIFF
--- a/main.go
+++ b/main.go
@@ -1098,8 +1098,8 @@ func main() {
 			Action: listPackages,
 		},
 		{
-			Name:   "auto",
-			Usage:  "Generate and commit changes",
+			Name:   "update",
+			Usage:  "Download and integrate new chart versions from upstreams",
 			Action: autoUpdate,
 			Flags: []cli.Flag{
 				cli.BoolFlag{

--- a/main.go
+++ b/main.go
@@ -872,13 +872,6 @@ func hideChart(c *cli.Context) error {
 	return nil
 }
 
-// CLI function call - Generates all changes for available packages,
-// Checking against upstream version, prepare, patch, clean, and index update
-// Does not commit
-func stageChanges(c *cli.Context) {
-	generateChanges(false)
-}
-
 // CLI function call - Generates automated commit
 func autoUpdate(c *cli.Context) {
 	generateChanges(true)
@@ -1115,11 +1108,6 @@ func main() {
 			Name:   "auto",
 			Usage:  "Generate and commit changes",
 			Action: autoUpdate,
-		},
-		{
-			Name:   "stage",
-			Usage:  "Stage all changes. Does not commit",
-			Action: stageChanges,
 		},
 		{
 			Name:   "hide",

--- a/main.go
+++ b/main.go
@@ -45,9 +45,10 @@ const (
 )
 
 var (
-	version = "v0.0.0"
-	commit  = "HEAD"
-	force   = false
+	version    = "v0.0.0"
+	commit     = "HEAD"
+	force      = false
+	makeCommit = false
 )
 
 // ChartWrapper is like a chart.Chart, but it tracks whether the chart
@@ -862,8 +863,10 @@ func autoUpdate(c *cli.Context) {
 		logrus.Error(err)
 	}
 
-	if err := commitChanges(paths, packageList); err != nil {
-		logrus.Fatal(err)
+	if makeCommit {
+		if err := commitChanges(paths, packageList); err != nil {
+			logrus.Fatal(err)
+		}
 	}
 }
 
@@ -1098,6 +1101,13 @@ func main() {
 			Name:   "auto",
 			Usage:  "Generate and commit changes",
 			Action: autoUpdate,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:        "commit, c",
+					Usage:       "Commit any changes",
+					Destination: &makeCommit,
+				},
+			},
 		},
 		{
 			Name:   "hide",


### PR DESCRIPTION
It is confusing to have both the `stage` and the `auto` subcommands because their effect is so similar. This PR merges the two subcommands into one, `update`, and allows for auto-committing changes through the `--commit` flag.