### PR TITLE
Fix file existence function and move to own package

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	p "github.com/rancher/partner-charts-ci/pkg/paths"
 	"github.com/rancher/partner-charts-ci/pkg/pkg"
 	"github.com/rancher/partner-charts-ci/pkg/upstreamyaml"
+	"github.com/rancher/partner-charts-ci/pkg/utils"
 	"github.com/rancher/partner-charts-ci/pkg/validate"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -259,7 +260,10 @@ func writeCharts(paths p.Paths, vendor, chartName string, chartWrappers []*Chart
 	for _, chartWrapper := range chartWrappers {
 		assetsFilename := getTgzFilename(chartWrapper.Chart)
 		assetsPath := filepath.Join(assetsDir, assetsFilename)
-		tgzFileExists := icons.Exists(assetsPath)
+		tgzFileExists, err := utils.Exists(assetsPath)
+		if err != nil {
+			return fmt.Errorf("failed to check %s for existence: %w", assetsPath, err)
+		}
 		if chartWrapper.Modified || !tgzFileExists {
 			_, err := chartutil.Save(chartWrapper.Chart, assetsDir)
 			if err != nil {
@@ -268,7 +272,10 @@ func writeCharts(paths p.Paths, vendor, chartName string, chartWrappers []*Chart
 		}
 
 		chartsPath := filepath.Join(chartsDir, chartWrapper.Metadata.Version)
-		chartsPathExists := icons.Exists(chartsPath)
+		chartsPathExists, err := utils.Exists(chartsPath)
+		if err != nil {
+			return fmt.Errorf("failed to check %s for existence: %w", chartsPath, err)
+		}
 		if chartWrapper.Modified || !chartsPathExists {
 			if err := conform.Gunzip(assetsPath, chartsPath); err != nil {
 				return fmt.Errorf("failed to unpack %q version %q to %q: %w", chartWrapper.Name(), chartWrapper.Metadata.Version, chartsPath, err)

--- a/main.go
+++ b/main.go
@@ -579,7 +579,7 @@ func writeIndex(paths p.Paths) error {
 			// the index.yaml. This works because Rancher uses the icon URL
 			// value from index.yaml, not the chart itself, when loading a chart's
 			// icon.
-			iconPath, err := icons.GetDownloadedIconPath(newChartVersion.Name)
+			iconPath, err := icons.GetDownloadedIconPath(paths, newChartVersion.Name)
 			if err != nil {
 				// TODO: return an error here instead of simply logging it.
 				// Logged errors can be ignored; errors that prevent the user
@@ -984,7 +984,7 @@ func removePackage(c *cli.Context) error {
 	}
 	removalPaths = append(removalPaths, assetFiles...)
 
-	localIconPath, err := icons.GetDownloadedIconPath(packageWrapper.Name)
+	localIconPath, err := icons.GetDownloadedIconPath(paths, packageWrapper.Name)
 	if err != nil {
 		logrus.Warnf("failed to get icon path for %s: %s", packageWrapper.FullName(), err)
 	} else {

--- a/pkg/icons/icons.go
+++ b/pkg/icons/icons.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 
 	p "github.com/rancher/partner-charts-ci/pkg/paths"
-	"github.com/sirupsen/logrus"
+	"github.com/rancher/partner-charts-ci/pkg/utils"
 )
 
 // possible extensions for the icons
@@ -20,7 +20,9 @@ var validExtensions []string = []string{".png", ".jpg", ".jpeg", ".svg", ".ico"}
 func GetDownloadedIconPath(packageName string) (string, error) {
 	for _, ext := range validExtensions {
 		filePath := fmt.Sprintf("assets/icons/%s%s", packageName, ext)
-		if exist := Exists(filePath); exist {
+		if exists, err := utils.Exists(filePath); err != nil {
+			return "", fmt.Errorf("failed to check %s for existence: %w", filePath, err)
+		} else if exists {
 			return filePath, nil
 		}
 	}
@@ -64,19 +66,6 @@ func EnsureIconDownloaded(paths p.Paths, iconUrl, packageName string) (string, e
 	}
 
 	return localIconPath, nil
-}
-
-// Exists checks if the file already exists
-func Exists(filePath string) bool {
-	_, err := os.Stat(filePath)
-	if os.IsNotExist(err) {
-		return false // File do not exist
-	} else if err == nil {
-		return true // File exists
-	}
-
-	logrus.Errorf("Error checking file: %s - error: %v", filePath, err)
-	return false // File might not exist
 }
 
 func getExtension(data []byte) (string, error) {

--- a/pkg/icons/icons.go
+++ b/pkg/icons/icons.go
@@ -17,9 +17,9 @@ var validExtensions []string = []string{".png", ".jpg", ".jpeg", ".svg", ".ico"}
 // GetDownloadedIconPath checks if the package with name packageName has
 // an icon downloaded. If so, it returns the path. Otherwise it returns
 // an error.
-func GetDownloadedIconPath(packageName string) (string, error) {
+func GetDownloadedIconPath(paths p.Paths, packageName string) (string, error) {
 	for _, ext := range validExtensions {
-		filePath := fmt.Sprintf("assets/icons/%s%s", packageName, ext)
+		filePath := filepath.Join(paths.Icons, packageName+ext)
 		if exists, err := utils.Exists(filePath); err != nil {
 			return "", fmt.Errorf("failed to check %s for existence: %w", filePath, err)
 		} else if exists {
@@ -34,7 +34,7 @@ func GetDownloadedIconPath(packageName string) (string, error) {
 // for package packageName. If a file already exists at this path, the
 // download is skipped. Returns the path to the icon.
 func EnsureIconDownloaded(paths p.Paths, iconUrl, packageName string) (string, error) {
-	if localIconPath, err := GetDownloadedIconPath(packageName); err == nil {
+	if localIconPath, err := GetDownloadedIconPath(paths, packageName); err == nil {
 		return localIconPath, nil
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"errors"
+	"os"
+)
+
+func Exists(filePath string) (bool, error) {
+	if _, err := os.Stat(filePath); err == nil {
+		return true, nil
+	} else if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else {
+		return false, err
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"os"
 )
 
+// Exists checks if a given file exists.
 func Exists(filePath string) (bool, error) {
 	if _, err := os.Stat(filePath); err == nil {
 		return true, nil


### PR DESCRIPTION
Also, there is a commit in this PR to use `paths.Paths` in `icons.GetDownloadedIconPath()`, which I somehow missed in #37.