### PR TITLE
When applying updates for a package fails, do not add update to commit message

### DIFF
--- a/main.go
+++ b/main.go
@@ -782,7 +782,6 @@ func autoUpdate(c *cli.Context) {
 			continue
 		}
 
-		logrus.Debugf("Populating package from %s\n", packageWrapper.Path)
 		updated, err := packageWrapper.Populate(paths)
 		if err != nil {
 			logrus.Errorf("failed to populate %s: %s", packageWrapper.FullName(), err)
@@ -793,7 +792,7 @@ func autoUpdate(c *cli.Context) {
 			logrus.Infof("%s is up-to-date\n", packageWrapper.FullName())
 		}
 		for _, version := range packageWrapper.FetchVersions {
-			logrus.Infof("\n  Package: %s\n  Source: %s\n  Version: %s\n  URL: %s  \n",
+			logrus.Infof("\n  Package: %s\n  Source: %s\n  Version: %s\n  URL: %s\n",
 				packageWrapper.FullName(), packageWrapper.SourceMetadata.Source, version.Version, version.URLs[0])
 		}
 
@@ -813,15 +812,15 @@ func autoUpdate(c *cli.Context) {
 			skippedList = append(skippedList, packageWrapper.Name)
 		}
 	}
+	if len(skippedList) >= len(packageList) {
+		logrus.Fatal("All packages skipped. Exiting...")
+	}
 	if len(skippedList) > 0 {
 		logrus.Errorf("Skipped due to error: %v", skippedList)
 	}
-	if len(skippedList) >= len(packageList) {
-		logrus.Fatalf("All packages skipped. Exiting...")
-	}
 
 	if err := writeIndex(paths); err != nil {
-		logrus.Error(err)
+		logrus.Fatalf("failed to write index.yaml: %s", err)
 	}
 
 	if makeCommit {

--- a/main.go
+++ b/main.go
@@ -782,7 +782,7 @@ func autoUpdate(c *cli.Context) {
 			continue
 		}
 
-		updated, err := packageWrapper.Populate(paths)
+		updatable, err := packageWrapper.Populate(paths)
 		if err != nil {
 			logrus.Errorf("failed to populate %s: %s", packageWrapper.FullName(), err)
 			continue
@@ -796,7 +796,7 @@ func autoUpdate(c *cli.Context) {
 				packageWrapper.FullName(), packageWrapper.SourceMetadata.Source, version.Version, version.URLs[0])
 		}
 
-		if updated {
+		if updatable {
 			updatablePackageWrappers = append(updatablePackageWrappers, packageWrapper)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -805,11 +805,14 @@ func autoUpdate(c *cli.Context) {
 		return
 	}
 
-	skippedList := make([]string, 0)
+	updatedPackageWrappers := make([]pkg.PackageWrapper, 0, len(updatablePackageWrappers))
+	skippedList := make([]string, 0, len(updatablePackageWrappers))
 	for _, packageWrapper := range updatablePackageWrappers {
 		if err := ApplyUpdates(paths, packageWrapper); err != nil {
 			logrus.Errorf("failed to apply updates for chart %q: %s", packageWrapper.Name, err)
 			skippedList = append(skippedList, packageWrapper.Name)
+		} else {
+			updatedPackageWrappers = append(updatedPackageWrappers, packageWrapper)
 		}
 	}
 	if len(skippedList) >= len(updatablePackageWrappers) {
@@ -824,8 +827,8 @@ func autoUpdate(c *cli.Context) {
 	}
 
 	if makeCommit {
-		if err := commitChanges(paths, updatablePackageWrappers); err != nil {
-			logrus.Fatal(err)
+		if err := commitChanges(paths, updatedPackageWrappers); err != nil {
+			logrus.Fatalf("failed to commit changes: %s", err)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -775,7 +775,7 @@ func autoUpdate(c *cli.Context) {
 		logrus.Fatalf("failed to list packages: %s", err)
 	}
 
-	packageList := make([]pkg.PackageWrapper, 0, len(packageWrappers))
+	updatablePackageWrappers := make([]pkg.PackageWrapper, 0, len(packageWrappers))
 	for _, packageWrapper := range packageWrappers {
 		if packageWrapper.UpstreamYaml.Deprecated {
 			logrus.Warnf("Package %s is deprecated; skipping update", packageWrapper.FullName())
@@ -797,22 +797,22 @@ func autoUpdate(c *cli.Context) {
 		}
 
 		if updated {
-			packageList = append(packageList, packageWrapper)
+			updatablePackageWrappers = append(updatablePackageWrappers, packageWrapper)
 		}
 	}
 
-	if len(packageList) == 0 {
+	if len(updatablePackageWrappers) == 0 {
 		return
 	}
 
 	skippedList := make([]string, 0)
-	for _, packageWrapper := range packageList {
+	for _, packageWrapper := range updatablePackageWrappers {
 		if err := ApplyUpdates(paths, packageWrapper); err != nil {
 			logrus.Errorf("failed to apply updates for chart %q: %s", packageWrapper.Name, err)
 			skippedList = append(skippedList, packageWrapper.Name)
 		}
 	}
-	if len(skippedList) >= len(packageList) {
+	if len(skippedList) >= len(updatablePackageWrappers) {
 		logrus.Fatal("All packages skipped. Exiting...")
 	}
 	if len(skippedList) > 0 {
@@ -824,7 +824,7 @@ func autoUpdate(c *cli.Context) {
 	}
 
 	if makeCommit {
-		if err := commitChanges(paths, packageList); err != nil {
+		if err := commitChanges(paths, updatablePackageWrappers); err != nil {
 			logrus.Fatal(err)
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue where the commit message produced by `partner-charts-ci update --commit` says a package was updated even if the update process (i.e. running `ApplyUpdates()` for that package) failed.