### PR TITLE
Deprecate `PackageVersion` field

### DIFF
--- a/pkg/conform/conform.go
+++ b/pkg/conform/conform.go
@@ -160,10 +160,6 @@ func GeneratePackageVersion(upstreamChartVersion string, packageVersion *int) (s
 			return "", fmt.Errorf("package version %d is greater than maximum of %d", *packageVersion, MaxPatchNum)
 		}
 
-		// TODO: when chartVersion.Patch() == 0, then we get a patch version of 1,
-		// assuming PatchVersion is set to 1 in the upstream.yaml (which it is for
-		// all packages that set PatchVersion at the time of writing). I don't
-		// think this is the intent of the function, so this behavior should be fixed.
 		patchVersion := PatchNumMultiplier*chartVersion.Patch() + uint64(*packageVersion)
 
 		split := strings.Split(chartVersion.String(), ".")

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -33,9 +33,15 @@ type UpstreamYaml struct {
 	HelmRepo           string         `json:"HelmRepo,omitempty"`
 	Hidden             bool           `json:"Hidden,omitempty"`
 	Namespace          string         `json:"Namespace,omitempty"`
-	PackageVersion     int            `json:"PackageVersion,omitempty"`
-	ReleaseName        string         `json:"ReleaseName,omitempty"`
-	Vendor             string         `json:"Vendor,omitempty"`
+	// PackageVersion is deprecated. It is deprecated because rancher/partner-charts
+	// updates are now automated, and this automation does not combine well with
+	// PackageVersion. Additionally, as of the time of writing, PackageVersion was
+	// never actually used. PackageVersion should not be added to any existing packages,
+	// nor should it be set in any new packages. For more information please see
+	// https://jira.suse.com/browse/SURE-9320.
+	PackageVersion int    `json:"PackageVersion,omitempty"`
+	ReleaseName    string `json:"ReleaseName,omitempty"`
+	Vendor         string `json:"Vendor,omitempty"`
 }
 
 func (upstreamYaml *UpstreamYaml) setDefaults() {


### PR DESCRIPTION
The `PackageVersion` field appears to have been introduced because of a now-removed dependency on [charts-build-scripts](https://github.com/rancher/charts-build-scripts). It does not appear to have ever been set to anything other than `1` on the packages that define it, so it was never necessary. Additionally it does not play well with the automated nature of rancher/partner-charts updates. Unfortunately it is difficult to remove, since doing so would deny users patch updates to charts that previously defined it until those charts release a new minor version.

This PR adds a comment to `UpstreamYaml.PackageVersion` that should help any future maintainers understand that it is deprecated and why. Updates to user-facing documentation will follow.