### PR TITLE
If `ReleaseName` is not set in `upstream.yaml`, fall back to package name

### DIFF
--- a/main.go
+++ b/main.go
@@ -430,7 +430,11 @@ func addAnnotations(packageWrapper pkg.PackageWrapper, helmChart *chart.Chart) e
 
 	annotations[annotationDisplayName] = packageWrapper.DisplayName
 
-	annotations[annotationReleaseName] = packageWrapper.UpstreamYaml.ReleaseName
+	if packageWrapper.UpstreamYaml.ReleaseName != "" {
+		annotations[annotationReleaseName] = packageWrapper.UpstreamYaml.ReleaseName
+	} else {
+		annotations[annotationReleaseName] = packageWrapper.Name
+	}
 
 	if packageWrapper.UpstreamYaml.Namespace != "" {
 		annotations[annotationNamespace] = packageWrapper.UpstreamYaml.Namespace

--- a/main_test.go
+++ b/main_test.go
@@ -182,7 +182,26 @@ func TestMain(t *testing.T) {
 			assert.Equal(t, displayName, value)
 		})
 
-		t.Run("should set release-name annotation properly", func(t *testing.T) {
+		t.Run("should set release-name annotation to package name when ReleaseName is not set", func(t *testing.T) {
+			packageName := "package-name"
+			packageWrapper := pkg.PackageWrapper{
+				Name:         packageName,
+				UpstreamYaml: &upstreamyaml.UpstreamYaml{},
+			}
+			helmChart := &chart.Chart{
+				Metadata: &chart.Metadata{
+					Dependencies: []*chart.Dependency{},
+				},
+			}
+			if err := addAnnotations(packageWrapper, helmChart); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			value, ok := helmChart.Metadata.Annotations[annotationReleaseName]
+			assert.True(t, ok)
+			assert.Equal(t, packageName, value)
+		})
+
+		t.Run("should set release-name annotation to ReleaseName when ReleaseName is set", func(t *testing.T) {
 			releaseName := "Release Name"
 			packageWrapper := pkg.PackageWrapper{
 				UpstreamYaml: &upstreamyaml.UpstreamYaml{

--- a/pkg/upstreamyaml/upstreamyaml.go
+++ b/pkg/upstreamyaml/upstreamyaml.go
@@ -48,10 +48,6 @@ func (upstreamYaml *UpstreamYaml) setDefaults() {
 	if upstreamYaml.Fetch == "" {
 		upstreamYaml.Fetch = "latest"
 	}
-
-	if upstreamYaml.ReleaseName == "" {
-		upstreamYaml.ReleaseName = upstreamYaml.HelmChart
-	}
 }
 
 func (upstreamYaml *UpstreamYaml) validate() error {

--- a/pkg/upstreamyaml/upstreamyaml_test.go
+++ b/pkg/upstreamyaml/upstreamyaml_test.go
@@ -22,25 +22,6 @@ func TestMain(t *testing.T) {
 				upstreamYaml.setDefaults()
 				assert.Equal(t, fetchValue, upstreamYaml.Fetch)
 			})
-
-			t.Run("should set ReleaseName field if not set", func(t *testing.T) {
-				helmChartValue := "helm-chart-value"
-				upstreamYaml := &UpstreamYaml{
-					HelmChart: helmChartValue,
-				}
-				upstreamYaml.setDefaults()
-				assert.Equal(t, helmChartValue, upstreamYaml.ReleaseName)
-			})
-
-			t.Run("should not change ReleaseName field if set", func(t *testing.T) {
-				releaseNameValue := "release-name-value"
-				upstreamYaml := &UpstreamYaml{
-					HelmChart:   "helm-chart-value",
-					ReleaseName: releaseNameValue,
-				}
-				upstreamYaml.setDefaults()
-				assert.Equal(t, releaseNameValue, upstreamYaml.ReleaseName)
-			})
 		})
 
 		t.Run("validate", func(t *testing.T) {

--- a/pkg/validate/matchnames.go
+++ b/pkg/validate/matchnames.go
@@ -24,7 +24,7 @@ func validateIndexYamlAndPackagesDirNamesMatch(paths p.Paths, _ ConfigurationYam
 func matchPackageNames(indexYaml *repo.IndexFile, packageWrappers []pkg.PackageWrapper) []error {
 	errors := make([]error, 0, len(packageWrappers))
 	indexYamlNames := map[string]bool{}
-	for chartName, _ := range indexYaml.Entries {
+	for chartName := range indexYaml.Entries {
 		indexYamlNames[chartName] = false
 	}
 	for _, packageWrapper := range packageWrappers {


### PR DESCRIPTION
This fixes a bug where charts whose upstream is not a helm repo (i.e. the upstream is an Artifact Hub repo or a Git repo) have the `catalog.cattle.io/release-name` annotation set to `""` as they are integrated. Instead of defaulting `ReleaseName` to the value of `HelmChart` (which is sometimes `""` in the aforementioned cases), we do not set a default. Instead, when setting the helm chart's annotations, we set the annotation to `ReleaseName` if it is set, and to the package name otherwise.