### PR TITLE
Print a more helpful error when upstream chart does not define an icon

### DIFF
--- a/main.go
+++ b/main.go
@@ -396,9 +396,15 @@ func applyOverlayFiles(overlayFiles map[string][]byte, helmChart *chart.Chart) e
 // icon file. We do this so that airgap installations of Rancher have access
 // to icons without needing to download them from a remote source.
 func ensureIcon(paths p.Paths, packageWrapper pkg.PackageWrapper, chartWrapper *ChartWrapper) error {
-	localIconPath, err := icons.EnsureIconDownloaded(paths, chartWrapper.Metadata.Icon, packageWrapper.Name)
+	localIconPath, err := icons.GetDownloadedIconPath(paths, packageWrapper.Name)
 	if err != nil {
-		return fmt.Errorf("failed to ensure icon downloaded: %w", err)
+		if chartWrapper.Metadata.Icon == "" {
+			return fmt.Errorf("chart does not define an icon, but an icon is required")
+		}
+		localIconPath, err = icons.DownloadIcon(paths, chartWrapper.Metadata.Icon, packageWrapper.Name)
+		if err != nil {
+			return fmt.Errorf("failed to ensure icon downloaded: %w", err)
+		}
 	}
 
 	localIconUrl := "file://" + localIconPath

--- a/pkg/icons/icons.go
+++ b/pkg/icons/icons.go
@@ -30,14 +30,9 @@ func GetDownloadedIconPath(paths p.Paths, packageName string) (string, error) {
 	return "", fmt.Errorf("no icon found for package %q", packageName)
 }
 
-// EnsureIconDownloaded downloads the icon at iconUrl to the icon file path
-// for package packageName. If a file already exists at this path, the
-// download is skipped. Returns the path to the icon.
-func EnsureIconDownloaded(paths p.Paths, iconUrl, packageName string) (string, error) {
-	if localIconPath, err := GetDownloadedIconPath(paths, packageName); err == nil {
-		return localIconPath, nil
-	}
-
+// DownloadIcon downloads the icon at iconUrl to the icon file path
+// for package packageName. Returns the path to the icon.
+func DownloadIcon(paths p.Paths, iconUrl, packageName string) (string, error) {
 	resp, err := http.Get(iconUrl)
 	if err != nil {
 		return "", fmt.Errorf("failed to http get %q: %w", iconUrl, err)


### PR DESCRIPTION
Example of an error due to the upstream chart not defining an icon prior to this change:
```
failed to apply updates for chart "dagger-helm": failed to reconcile charts for package "dagger-helm":
failed to ensure icon for chart "dagger-helm" version "0.18.5": failed to ensure icon downloaded:
failed to http get "": Get "": unsupported protocol scheme ""
```
How the error would look after this change:
```
failed to apply updates for chart "dagger-helm": failed to reconcile charts for package "dagger-helm":
failed to ensure icon for chart "dagger-helm" version "0.18.5": failed to ensure icon downloaded:
chart does not define an icon, but an icon is required
```